### PR TITLE
get_highest_res() method addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,13 @@ video = yt.get('mp4')
 # In this case, we'll need to specify both the codec (mp4) and resolution
 # (either 360p or 720p).
 
+# We can also get the highest resolution available using the 
+# get_highest_quality() method. An optional preferred filetype extension can be 
+# specified as a string, otherwise we default to 'mp4', if available. The function
+# will favour the highest quality over the preferred filetype, though.
+
+video = yt.get_highest_res(preferred='mp4')
+
 # Okay, let's download it!
 video.download()
 

--- a/README.md
+++ b/README.md
@@ -115,8 +115,7 @@ video = yt.get('mp4')
 # We can also get the highest resolution available using the 
 # get_highest_quality() method. An optional preferred filetype extension can be 
 # specified as a string, otherwise we default to 'mp4', if available. The function
-# will favour the highest quality over the preferred filetype, though.
-
+# will favour the highest quality over the preferred filetype.
 video = yt.get_highest_res(preferred='mp4')
 
 # Okay, let's download it!

--- a/pytube/__init__.py
+++ b/pytube/__init__.py
@@ -196,6 +196,26 @@ class YouTube(object):
             raise MultipleObjectsReturned("get() returned more than one "
                                           "object -- it returned %d!" % d)
 
+    def get_highest_res(self, preferred='mp4'):
+        """
+        Return the highest quality resolution available that matches the 
+        preferred filetype, if available. Will favour the highest quality 
+        over the preferred filetype. If not available, the highest 
+        quality that matches any filetype is returned.
+
+        Keyword arguments:
+        preferred -- the preferred extension (e.g.: mp4) 
+        """
+        highest, result = 0, None
+        for v in self.videos:
+            current = int(v.resolution[:-1])
+            if ((current > highest) or 
+                (current == highest and v.extension == preferred)):
+                highest = current
+                result = v
+
+        return result
+
     def filter(self, extension=None, res=None):
         """
         Return a filtered list of videos given an extention and


### PR DESCRIPTION
Submitting a proposal for a new method called get_highest_res(). It allows the user to automatically get the highest Youtube resolution. They can also specify the preferred file format, though it will favour highest quality over preferred format.

Here it is in action against your Readme example:

```
>>> from pytube import YouTube
>>> from pprint import pprint
>>> yt = YouTube()
>>> yt.url = "http://www.youtube.com/watch?v=Ik-RsDGPI5Y"
>>> pprint(yt.videos)
[<Video: MPEG-4 Visual (.3gp) - 144p>,
 <Video: MPEG-4 Visual (.3gp) - 240p>,
 <Video: Sorenson H.263 (.flv) - 240p>,
 <Video: H.264 (.flv) - 360p>,
 <Video: H.264 (.flv) - 480p>,
 <Video: H.264 (.mp4) - 360p>,
 <Video: H.264 (.mp4) - 720p>,
 <Video: VP8 (.webm) - 360p>,
 <Video: VP8 (.webm) - 480p>,
 <Video: VP8 (.webm) - 720p>]
>>> yt.get_highest_res('webm')
<Video: VP8 (.webm) - 720p>
>>> yt.get_highest_res()
<Video: H.264 (.mp4) - 720p>
>>> yt.get_highest_res('flv')
<Video: H.264 (.mp4) - 720p>
```
