### PR TITLE
Video info parsing and Python 3 fixes

### DIFF
--- a/pytube/api.py
+++ b/pytube/api.py
@@ -5,7 +5,7 @@ from .models import Video
 from .utils import safe_filename
 from urllib import urlencode
 from urllib2 import urlopen
-from urlparse import urlparse, parse_qs
+from urlparse import urlparse, parse_qs, unquote
 
 import re
 
@@ -174,6 +174,35 @@ class YouTube(object):
             # Nope, let's keep diggin'
             return self._fetch(path, data)
 
+    def _parse_stream_map(self, data):
+        """
+        Python's `parse_qs` can't properly decode the stream map 
+        containing video data so we use this instead.
+
+        Keyword arguments:
+        data -- The parsed response from YouTube.
+        """
+        videoinfo = {
+            "itag": [], 
+            "url": [], 
+            "quality": [], 
+            "fallback_host": [], 
+            "sig": [], 
+            "type": []
+        }
+        text = data["url_encoded_fmt_stream_map"][0]
+        # Split individual videos
+        videos = text.split(",") 
+        # Unquote the characters and split to parameters
+        videos = [video.split("&") for video in videos]
+
+        for video in videos:
+            for kv in video:
+                key, value = kv.split("=")
+                videoinfo.get(key, []).append(unquote(value))
+
+        return videoinfo
+
     def _get_video_info(self):
         """
         This is responsable for executing the request, extracting the
@@ -197,13 +226,10 @@ class YouTube(object):
                     error = error.pop()
                 raise YouTubeError(error)
 
-            #Use my cool traversing method to extract the specific
-            #attribute from the response body.
-            path = ('url_encoded_fmt_stream_map', 'url')
-            video_urls = self._fetch(path, content)
+            stream_map = self._parse_stream_map(data)
+            video_urls = stream_map["url"]
             #Get the video signatures, YouTube require them as an url component
-            path = ('url_encoded_fmt_stream_map', 'sig')
-            video_signatures = self._fetch(path, content)
+            video_signatures = stream_map["sig"]
             self.title = self._fetch(('title',), content)
 
             for idx in range(len(video_urls)):

--- a/pytube/api.py
+++ b/pytube/api.py
@@ -88,6 +88,9 @@ class YouTube(object):
     def filename(self, filename):
         """ Defines the filename."""
         self._filename = filename
+        if self.videos:
+            for video in self.videos:
+                video.filename = filename
 
     @property
     def video_id(self):
@@ -237,13 +240,12 @@ class YouTube(object):
                 signature = video_signatures[idx]
                 try:
                     fmt, data = self._extract_fmt(url)
-                    filename = "%s.%s" % (self.filename, data['extension'])
                 except (TypeError, KeyError):
                     pass
                 else:
                     #Add video signature to url
                     url = "%s&signature=%s" % (url, signature)
-                    v = Video(url, filename, **data)
+                    v = Video(url, self.filename, **data)
                     self.videos.append(v)
                     self._fmt_values.append(fmt)
             self.videos.sort()

--- a/pytube/models.py
+++ b/pytube/models.py
@@ -39,7 +39,6 @@ class Video(object):
             file_size = int(meta_data.get("Content-Length") or
                             meta_data.get("content-length"))
             self._bytes_received = 0
-            self._buffer = buffer
             while True:
                 self._buffer = response.read(chunk_size)
                 if not self._buffer:

--- a/pytube/models.py
+++ b/pytube/models.py
@@ -33,8 +33,9 @@ class Video(object):
         """
 
         path = (normpath(path) + '/' if path else '')
+        fullpath = '%s%s.%s' % (path, self.filename, self.extension)
         response = urlopen(self.url)
-        with open(path + self.filename, 'wb') as dst_file:
+        with open(path + self.filename + '.' + self.extension, 'wb') as dst_file:
             meta_data = dict(response.info().items())
             file_size = int(meta_data.get("Content-Length") or
                             meta_data.get("content-length"))

--- a/pytube/models.py
+++ b/pytube/models.py
@@ -35,7 +35,7 @@ class Video(object):
         path = (normpath(path) + '/' if path else '')
         fullpath = '%s%s.%s' % (path, self.filename, self.extension)
         response = urlopen(self.url)
-        with open(path + self.filename + '.' + self.extension, 'wb') as dst_file:
+        with open(fullpath, 'wb') as dst_file:
             meta_data = dict(response.info().items())
             file_size = int(meta_data.get("Content-Length") or
                             meta_data.get("content-length"))


### PR DESCRIPTION
[This](https://github.com/NFicano/python-youtube-download/commit/f9849241120e9bec548f8d7113409d2be6291a0c) commit broke compatibility with Python 3. In line  41 `self._buffer` is set to `buffer` which doesn't exists in 3.X.

The equivalent would be `memoryview` which works in 2.7+ but seeing as `buffer` was not used at all, (It was overridden two lines below) I just removed it.
