### PR TITLE
YouTube changed something?

### DIFF
--- a/pytube/api.py
+++ b/pytube/api.py
@@ -232,21 +232,16 @@ class YouTube(object):
 
             stream_map = self._parse_stream_map(data)
             video_urls = stream_map["url"]
-            #Get the video signatures, YouTube require them as an url component
             #Apparently signatures are not needed as of 2014-02-28
-            #video_signatures = stream_map["sig"]
             self.title = self._fetch(('title',), content)
 
             for idx in range(len(video_urls)):
                 url = video_urls[idx]
-                #signature = video_signatures[idx]
                 try:
                     fmt, data = self._extract_fmt(url)
                 except (TypeError, KeyError):
                     pass
                 else:
-                    #Add video signature to url
-                    #url = "{0}&signature={1}".format(url, signature)
                     v = Video(url, self.filename, **data)
                     self.videos.append(v)
                     self._fmt_values.append(fmt)

--- a/pytube/api.py
+++ b/pytube/api.py
@@ -233,19 +233,20 @@ class YouTube(object):
             stream_map = self._parse_stream_map(data)
             video_urls = stream_map["url"]
             #Get the video signatures, YouTube require them as an url component
-            video_signatures = stream_map["sig"]
+            #Apparently signatures are not needed as of 2014-02-28
+            #video_signatures = stream_map["sig"]
             self.title = self._fetch(('title',), content)
 
             for idx in range(len(video_urls)):
                 url = video_urls[idx]
-                signature = video_signatures[idx]
+                #signature = video_signatures[idx]
                 try:
                     fmt, data = self._extract_fmt(url)
                 except (TypeError, KeyError):
                     pass
                 else:
                     #Add video signature to url
-                    url = "{0}&signature={1}".format(url, signature)
+                    #url = "{0}&signature={1}".format(url, signature)
                     v = Video(url, self.filename, **data)
                     self.videos.append(v)
                     self._fmt_values.append(fmt)


### PR DESCRIPTION
I removed the video signatures. They are already included in the URL string, and apparently the old way of grabbing stream_map["sig"] returns an empty list, which returns an error in line 242
