### PR TITLE
fixed printing  status, flushes previous status in terminal

### DIFF
--- a/pytube/utils.py
+++ b/pytube/utils.py
@@ -1,5 +1,5 @@
 import re
-
+from sys import stdout
 
 def safe_filename(text, max_length=200):
     """
@@ -41,4 +41,5 @@ def print_status(progress, file_size):
     percent = progress * 100. / file_size
     status = r"{0:10d}  [{1:3.2f}%]".format(progress, percent)
     status = status + chr(8) * (len(status) + 1)
-    print(status,)
+    stdout.write('%s\r' % status)
+    stdout.flush()


### PR DESCRIPTION
Hi, I have made change that the printed status of percentage done is updated, flushing the old one and updating the shell with new one.
