### PR TITLE
Fix for two videos with same extension and resolution.

### DIFF
--- a/pytube/api.py
+++ b/pytube/api.py
@@ -38,7 +38,7 @@ YT_ENCODING = {
     82: ["mp4", "360p", "H.264", "3D", "0.5", "AAC", "96"],
     83: ["mp4", "240p", "H.264", "3D", "0.5", "AAC", "96"],
     84: ["mp4", "720p", "H.264", "3D", "2-2.9", "AAC", "152"],
-    85: ["mp4", "520p", "H.264", "3D", "2-2.9", "AAC", "152"],
+    85: ["mp4", "1080p", "H.264", "3D", "2-2.9", "AAC", "152"],
 
     #WebM
     43: ["webm", "360p", "VP8", "N/A", "0.5", "Vorbis", "128"],
@@ -110,7 +110,7 @@ class YouTube(object):
             if video_id:
                 return video_id.pop()
 
-    def get(self, extension=None, resolution=None):
+    def get(self, extension=None, resolution=None, profile="High"):
         """
         Return a single video given an extention and resolution.
 
@@ -123,6 +123,8 @@ class YouTube(object):
             if extension and v.extension != extension:
                 continue
             elif resolution and v.resolution != resolution:
+                continue
+            elif profile and v.profile != profile:
                 continue
             else:
                 result.append(v)

--- a/pytube/models.py
+++ b/pytube/models.py
@@ -100,8 +100,8 @@ class Video(object):
 
     def __repr__(self):
         """A cleaner representation of the class instance."""
-        return "<Video: {0} (.{1}) - {2}>".format(self.video_codec, self.extension,
-                                           self.resolution)
+        return "<Video: {0} (.{1}) - {2} - {3}>".format(self.video_codec, self.extension,
+                                           self.resolution, self.profile)
 
     def __lt__(self, other):
         if type(other) == Video:


### PR DESCRIPTION
Two videos can have the same extension and resolution but a different profile.
Because the get function only uses extension and resolution, it can't tel which video has to be downloaded.

api.py and models.py have been modified to set also the profile to be downloaded and avoid this problem.
