### PR TITLE
Unify event, speaker, tags list display

### DIFF
--- a/themes/pytube-201601/static/css/base.css
+++ b/themes/pytube-201601/static/css/base.css
@@ -130,20 +130,41 @@ h1 {
   margin-top: 0;
 }
 
-/* speaker list styles */
-.listNav {
-  padding: 5px 0px;
-}
-
-#speaker-list li {
-  width: 33%;
-  float: left;
-}
-
 .container {
   margin: auto;
 }
 
+/* list styles (speakers, events, tags) */
+.listNav {
+  padding: 5px 0;
+  margin-bottom: 5px;
+}
+
+.ln-letters a {
+  display: inline-block;
+  width: calc(100% / 28);
+}
+
+@media screen and (max-width: 768px) {
+  .ln-letters a {
+    width: calc(100% / 14);
+  }
+  .ln-letters a:nth-child(-n+14) {
+    border-bottom: none;
+  }
+
+}
+
+#element-list li {
+  float: left;
+  margin-bottom: 3px;
+}
+
+#element-list li .badge {
+  background-color: #ffd343;
+  color: #2b5b84;
+  float: right;
+}
 
 .header__title,
 .header__searchbox {

--- a/themes/pytube-201601/templates/authors.html
+++ b/themes/pytube-201601/templates/authors.html
@@ -1,20 +1,16 @@
-{% extends "base.html" %}
+{% extends "list_filterable.html" %}
 
 {% block subtitle %} &middot; Speakers{% endblock %}
-{% block head %}
-    {{ super()}}
-    <link href="/theme/css/jquery-listnav.css" rel="stylesheet">
-{% endblock %}
 
 {% block content %}
 
 <h1>All Speakers</h1>
 
 <div class="row">
-    <ul id="speaker-list">
+    <ul id="element-list">
       {% for author, articles in authors|sort %}
-        <li>
-          <a href="{{ SITEURL }}/{{ author.url }}">{{ author }} ({{ articles|length }})</a>
+        <li class="col-md-4  col-xs-6">
+          <a href="{{ SITEURL }}/{{ author.url }}">{{ author }}</a> <span class="badge">{{ articles|length }}</span>
         </li>
       {% endfor %}
     </ul>
@@ -22,14 +18,3 @@
 
 {% endblock %}
 
-{% block endbodyjs %}
-    {{ super() }}
-      <script src="/theme/js/jquery-listnav.js"></script>
-      <script>
-        $("#speaker-list").listnav({
-            includeOther: true,
-            includeNums: false,
-            showCounts: false
-        });
-      </script>
-{% endblock %}

--- a/themes/pytube-201601/templates/categories.html
+++ b/themes/pytube-201601/templates/categories.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "list_filterable.html" %}
 
 {% block subtitle %} &middot; Events{% endblock %}
 
@@ -6,12 +6,14 @@
 
 <h2>All Events</h2>
 
-<ul>
-  {% for category, articles in categories %}
-    <li>
-      <a href="{{ SITEURL }}/{{ category.url }}">{{ category }}</a>
-    </li>
-  {% endfor %}
-</ul>
+<div class="row">
+    <ul id="element-list">
+      {% for category, articles in categories %}
+        <li class="col-md-4 col-xs-6">
+          <a href="{{ SITEURL }}/{{ category.url }}">{{ category }}</a> <span class="badge">{{ articles|length }}</span>
+        </li>
+      {% endfor %}
+    </ul>
+</div>
 
 {% endblock %}

--- a/themes/pytube-201601/templates/list_filterable.html
+++ b/themes/pytube-201601/templates/list_filterable.html
@@ -1,0 +1,20 @@
+{# This is used as the common base template for the authors, categories and tags pages #}
+{% extends "base.html" %}
+
+{% block head %}
+    {{ super()}}
+    <link href="/theme/css/jquery-listnav.css" rel="stylesheet">
+{% endblock %}
+
+{% block endbodyjs %}
+    {{ super() }}
+      <script src="/theme/js/jquery-listnav.js"></script>
+      <script>
+        $("#element-list").listnav({
+            includeOther: true,
+            includeNums: false,
+            showCounts: false
+        });
+      </script>
+{% endblock %}
+

--- a/themes/pytube-201601/templates/tags.html
+++ b/themes/pytube-201601/templates/tags.html
@@ -1,15 +1,20 @@
-{% extends "base.html" %}
+{% extends "list_filterable.html" %}
 
 {% block subtitle %} &middot; Tags{% endblock %}
 
 {% block content %}
-  <h2>All Tags</h2>
-  <ul>
-  {%- for tag, articles in tags|sort %}
-    <li>
-      <a href="{{ SITEURL }}/{{ tag.url }}">{{ tag }}</a> ({{ articles|count }})
-    </li>
-  {% endfor %}
-  </ul>
+
+<h2>All Tags</h2>
+
+<div class="row">
+    <ul id="element-list">
+      {%- for tag, articles in tags|sort %}
+        <li class="col-md-3 col-sm-4 col-xs-6">
+           <a href="{{ SITEURL }}/{{ tag.url }}">{{ tag }}</a> <span class="badge">{{ articles|length }}</span>
+        </li>
+      {% endfor %}
+    </ul>
+</div>
+
 {% endblock %}
 


### PR DESCRIPTION
Use a common base template and similar styles for all three pages displaying links.