### PR TITLE
Add feeds (all, speaker, conference).

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -31,6 +31,11 @@ YEAR_ARCHIVE_SAVE_AS = 'archives/{date:%Y}/index.html'
 MONTH_ARCHIVE_SAVE_AS = 'archives/{date:%Y}/{date:%b}/index.html'
 CATEGORIES_SAVE_AS = 'events.html'
 
+# Feeds
+FEED_RSS = 'rss.xml'
+CATEGORY_FEED_RSS = 'events/%s/rss.xml'
+AUTHOR_FEED_RSS = 'author/%s/rss.xml'
+
 # Uncomment following line if you want document-relative URLs when developing
 RELATIVE_URLS = True
 


### PR DESCRIPTION
Fixes #67 

Pretty easy change.

Urls are like so:

all: http://localhost:8000/rss.xml
speaker: http://localhost:8000/author/aaron-hall/rss.xml
conference: http://localhost:8000/events/djangocon-au-2013/rss.xml