### PR TITLE
Fix default category and "speaker" file names

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -33,6 +33,8 @@ MONTH_ARCHIVE_SAVE_AS = 'archives/{date:%Y}/{date:%b}/index.html'
 CATEGORIES_SAVE_AS = 'events.html'
 AUTHORS_SAVE_AS = 'speakers.html'
 
+USE_FOLDER_AS_CATEGORY = False
+
 # Feeds
 FEED_RSS = 'rss.xml'
 CATEGORY_FEED_RSS = 'events/%s/rss.xml'

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -15,6 +15,7 @@ DEFAULT_LANG = 'en'
 
 DEFAULT_PAGINATION = 10
 
+AUTHOR_URL = AUTHOR_SAVE_AS = 'speaker/{slug}.html'
 ARTICLE_URL = ARTICLE_SAVE_AS = '{category}/{slug}.html'
 ARTICLE_LANG_URL = ARTICLE_LANG_SAVE_AS = '{category}/{slug}-{lang}.html'
 DRAFT_URL = DRAFT_SAVE_AS = 'drafts/{category}/{slug}.html'
@@ -30,6 +31,7 @@ TAG_SAVE_AS = 'tag/{slug}/index.html'
 YEAR_ARCHIVE_SAVE_AS = 'archives/{date:%Y}/index.html'
 MONTH_ARCHIVE_SAVE_AS = 'archives/{date:%Y}/{date:%b}/index.html'
 CATEGORIES_SAVE_AS = 'events.html'
+AUTHORS_SAVE_AS = 'speakers.html'
 
 # Feeds
 FEED_RSS = 'rss.xml'

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -15,6 +15,8 @@ DEFAULT_LANG = 'en'
 
 DEFAULT_PAGINATION = 10
 
+DEFAULT_CATEGORY = "Undefined"
+
 AUTHOR_URL = AUTHOR_SAVE_AS = 'speaker/{slug}.html'
 ARTICLE_URL = ARTICLE_SAVE_AS = '{category}/{slug}.html'
 ARTICLE_LANG_URL = ARTICLE_LANG_SAVE_AS = '{category}/{slug}-{lang}.html'

--- a/plugins/json_reader.py
+++ b/plugins/json_reader.py
@@ -85,7 +85,8 @@ class JSONReader(BaseReader):
             json_data = json.loads(f.read())
 
         metadata = {'title': _get_and_check_none(json_data, 'title', 'Title'),
-                    'category': _get_and_check_none(json_data, 'category', 'Default'),
+                    'category': _get_and_check_none(json_data, 'category',
+                                                    self.settings['DEFAULT_CATEGORY']),
                     'tags': _get_and_check_none(json_data, 'tags', []),
                     'date': _get_and_check_none(json_data, 'recorded', '1990-01-01'),
                     'slug': _get_and_check_none(json_data, 'slug', 'Slug'),

--- a/themes/pytube-201601/templates/base.html
+++ b/themes/pytube-201601/templates/base.html
@@ -74,8 +74,8 @@
           <a href="{{ SITEURL }}/tags.html"><i class="fa fa-fw fa-tags"></i> <span>Tags</span></a>
         </li>
 
-        <li role="presentation"{% if output_file == "authors.html" or output_file.startswith("author/") %} class="active"{% endif %}>
-          <a href="{{ SITEURL }}/authors.html"><i class="fa fa-fw fa-users"></i> <span>Speakers</span></a>
+        <li role="presentation"{% if output_file == "speakers.html" or output_file.startswith("speaker/") %} class="active"{% endif %}>
+          <a href="{{ SITEURL }}/speakers.html"><i class="fa fa-fw fa-users"></i> <span>Speakers</span></a>
         </li>
 
         {% for p in pages %}


### PR DESCRIPTION
* Rename speaker related files
* Fix the default category name and configure Pelican to no longer use folder names as categories