### PR TITLE
Extract event information from category.json files

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -72,5 +72,5 @@ EXTRA_PATH_METADATA = {
 #sys.path.append(os.path.abspath("."))
 #from plugins import json_reader
 PLUGIN_PATHS = ['plugins']
-PLUGINS = ['json_reader', 'bin.plugins', 'extended_sitemap', 'bin.aggregations']
+PLUGINS = ['json_reader', 'bin.plugins', 'extended_sitemap', 'bin.aggregations', 'event_info']
 #PLUGINS = ['bin.plugins', 'extended_sitemap']

--- a/plugins/event_info.py
+++ b/plugins/event_info.py
@@ -1,0 +1,49 @@
+import docutils
+import docutils.io
+import io
+import json
+
+from pelican.readers import PelicanHTMLTranslator
+from pelican import generators
+from pelican import signals
+from pathlib import Path
+
+
+def _generate_html(data):
+    extra_params = {'initial_header_level': '2',
+                    'syntax_highlight': 'short',
+                    'input_encoding': 'utf-8',
+                    'exit_status_level': 2,
+                    'compact_p': False,
+                    'embed_stylesheet': False}
+    pub = docutils.core.Publisher(
+        source_class=docutils.io.StringInput,
+        destination_class=docutils.io.StringOutput)
+    pub.set_components('standalone', 'restructuredtext', 'html')
+    pub.writer.translator_class = PelicanHTMLTranslator
+    pub.process_programmatic_settings(None, extra_params, None)
+    pub.set_source(source=data, source_path=None)
+    pub.publish(enable_exit_status=True)
+    return pub.writer.parts['body']
+
+
+def _collect_event_info(generator):
+    collected_metadata = {}
+    if isinstance(generator, generators.ArticlesGenerator):
+        for event in [x[0] for x in generator.categories]:
+            event.meta = _load_event_metadata(event.slug)
+
+
+def _load_event_metadata(slug):
+    path = Path('content') / 'conferences' / slug / 'category.json'
+    if not path.exists():
+        return None
+    with io.open(str(path), encoding='utf-8') as fp:
+        data = json.load(fp)
+        if data['description']:
+            data['description'] = _generate_html(data['description'])
+        return data
+
+
+def register():
+    signals.article_generator_finalized.connect(_collect_event_info)

--- a/themes/pytube-201601/static/css/base.css
+++ b/themes/pytube-201601/static/css/base.css
@@ -95,7 +95,6 @@ article.list_item div {
     margin-bottom: 40px;
 }
 
-
 div.index-content h3 {
   margin-top: 0px;
   margin-bottom: 20px;
@@ -289,5 +288,6 @@ input.gsc-input,
   display: none;
 }
 
-.info--stats {
+.event__description {
+  margin-bottom: 40px;
 }

--- a/themes/pytube-201601/templates/category.html
+++ b/themes/pytube-201601/templates/category.html
@@ -5,6 +5,12 @@
 {% block content %}
   <h2>Event: {{ category }}</h2>
 
+  {% if category.meta and category.meta.description %}
+  <section class="event__description">
+      {{ category.meta.description|safe }}
+  </section>
+  {% endif %}
+
   <div class="row">
     <div class="col-lg-12">
       <ul class="content-list">


### PR DESCRIPTION
... and render it on each event page. This assumes that the description is encoded as ReST and that docutils escapes HTML on its own.

<img style="max-width: 764px" alt="pytube_org_ _djangocon_2010" src="https://cloud.githubusercontent.com/assets/3782/15801447/c9c2b328-2a49-11e6-9797-e2abe2a258aa.png">
