### PR TITLE
More accessibility tests and fixes

### DIFF
--- a/tests/pages.py
+++ b/tests/pages.py
@@ -2,8 +2,10 @@
 from pathlib import Path
 
 from bok_choy.page_object import PageObject
+from selenium.webdriver.common.keys import Keys
 
 PORT = 8081
+TITLE_TEMPLATE = 'PyTube.org \u00B7 {}'
 
 
 class AboutPage(PageObject):
@@ -13,7 +15,17 @@ class AboutPage(PageObject):
     url = 'http://localhost:{}/pages/about.html'.format(PORT)
 
     def is_browser_on_page(self):
-        return self.browser.title == 'PyTube.org \u00B7 About'
+        return self.browser.title == TITLE_TEMPLATE.format('About')
+
+
+class EventPage(PageObject):
+    """
+    Testing representation of a sample event page
+    """
+    url = 'http://localhost:{}/events/pydata.html'.format(PORT)
+
+    def is_browser_on_page(self):
+        return self.browser.title == TITLE_TEMPLATE.format('PyData')
 
 
 class EventsPage(PageObject):
@@ -23,7 +35,7 @@ class EventsPage(PageObject):
     url = 'http://localhost:{}/events.html'.format(PORT)
 
     def is_browser_on_page(self):
-        return self.browser.title == 'PyTube.org \u00B7 Events'
+        return self.browser.title == TITLE_TEMPLATE.format('Events')
 
 
 class IndexPage(PageObject):
@@ -35,6 +47,45 @@ class IndexPage(PageObject):
     def is_browser_on_page(self):
         return self.browser.title == 'PyTube.org'
 
+    def search(self, phrase):
+        """
+        Enter a search phrase and display the results
+        """
+        selector = 'input.gsc-input'
+        self.wait_for_element_visibility(selector, 'Search input available')
+        self.q(css=selector).fill(phrase + Keys.ENTER)
+        self.wait_for_element_visibility('.gsc-results', 'Search results shown')
+
+
+class MP4Page(PageObject):
+    """
+    Testing representation of a sample MP4 video page
+    """
+    url = 'http://localhost:{}/pyohio-2011/pyohio-2011--saturday-lightning-talks.html'.format(PORT)
+
+    def is_browser_on_page(self):
+        return self.browser.title == TITLE_TEMPLATE.format('PyOhio 2011: Saturday Lightning Talks')
+
+
+class OGVPage(PageObject):
+    """
+    Testing representation of a sample OGV video page
+    """
+    url = 'http://localhost:{}/pycon-za-2013/python-in-debian-and-ubuntu.html'.format(PORT)
+
+    def is_browser_on_page(self):
+        return self.browser.title == TITLE_TEMPLATE.format('Python in Debian and Ubuntu')
+
+
+class SpeakerPage(PageObject):
+    """
+    Testing representation of a sample speaker page
+    """
+    url = 'http://localhost:{}/speaker/glyph.html'.format(PORT)
+
+    def is_browser_on_page(self):
+        return self.browser.title == TITLE_TEMPLATE.format('Glyph')
+
 
 class SpeakersPage(PageObject):
     """
@@ -43,7 +94,17 @@ class SpeakersPage(PageObject):
     url = 'http://localhost:{}/speakers.html'.format(PORT)
 
     def is_browser_on_page(self):
-        return self.browser.title == 'PyTube.org \u00B7 Speakers'
+        return self.browser.title == TITLE_TEMPLATE.format('Speakers')
+
+
+class TagPage(PageObject):
+    """
+    Testing representation of a sample tag page
+    """
+    url = 'http://localhost:{}/tag/subtitles/'.format(PORT)
+
+    def is_browser_on_page(self):
+        return self.browser.title == TITLE_TEMPLATE.format('subtitles')
 
 
 class TagsPage(PageObject):
@@ -53,4 +114,24 @@ class TagsPage(PageObject):
     url = 'http://localhost:{}/tags.html'.format(PORT)
 
     def is_browser_on_page(self):
-        return self.browser.title == 'PyTube.org \u00B7 Tags'
+        return self.browser.title == TITLE_TEMPLATE.format('Tags')
+
+
+class VimeoPage(PageObject):
+    """
+    Testing representation of a sample Vimeo video page
+    """
+    url = 'http://localhost:{}/boston-python-meetup/boston-python-meetup--testing--where-do-i-start.html'.format(PORT)
+
+    def is_browser_on_page(self):
+        return self.browser.title == TITLE_TEMPLATE.format('Boston Python Meetup: Testing: Where do I start?')
+
+
+class YouTubePage(PageObject):
+    """
+    Testing representation of a sample YouTube video page
+    """
+    url = 'http://localhost:{}/europython-2011/browse-and-print-problems-and-solutions.html'.format(PORT)
+
+    def is_browser_on_page(self):
+        return self.browser.title == TITLE_TEMPLATE.format('Browse and print problems and solutions')

--- a/tests/test_a11y.py
+++ b/tests/test_a11y.py
@@ -8,7 +8,10 @@ from bok_choy.web_app_test import WebAppTest
 from pelican.server import ComplexHTTPRequestHandler
 import requests
 
-from .pages import AboutPage, EventsPage, IndexPage, PORT, SpeakersPage, TagsPage
+from .pages import (
+    AboutPage, EventPage, EventsPage, MP4Page, IndexPage, OGVPage, PORT,
+    SpeakerPage, SpeakersPage, TagPage, TagsPage, VimeoPage, YouTubePage
+)
 
 def start_pelican():
     os.chdir('output')
@@ -49,6 +52,12 @@ class TestAccessibility(WebAppTest):
         """
         self._check_a11y(AboutPage)
 
+    def test_event(self):
+        """
+        The page for a single event should have good accessibility
+        """
+        self._check_a11y(EventPage)
+
     def test_events(self):
         """
         The events listing page should have good accessibility
@@ -61,11 +70,32 @@ class TestAccessibility(WebAppTest):
         """
         self._check_a11y(IndexPage)
 
+    def test_search_results(self):
+        """
+        The search results should have good accessibility
+        """
+        page = IndexPage(self.browser)
+        page.visit()
+        page.search('accessibility')
+        page.a11y_audit.check_for_accessibility_errors()
+
+    def test_speaker(self):
+        """
+        The page for a single speaker should have good accessibility
+        """
+        self._check_a11y(SpeakerPage)
+
     def test_speakers(self):
         """
         The speakers listing page should have good accessibility
         """
         self._check_a11y(SpeakersPage)
+
+    def test_tag(self):
+        """
+        The page for a single tag should have good accessibility
+        """
+        self._check_a11y(TagPage)
 
     def test_tags(self):
         """
@@ -73,13 +103,39 @@ class TestAccessibility(WebAppTest):
         """
         self._check_a11y(TagsPage)
 
+    def test_video_mp4(self):
+        """
+        Video pages using MP4 files should have good accessibility
+        """
+        self._check_a11y(MP4Page)
+
+    def test_video_ogv(self):
+        """
+        Video pages using OGV files should have good accessibility
+        """
+        self._check_a11y(OGVPage)
+
+    def test_video_vimeo(self):
+        """
+        Video pages using Vimeo should have good accessibility
+        """
+        self._check_a11y(VimeoPage)
+
+    def test_video_youtube(self):
+        """
+        Video pages using YouTube should have good accessibility
+        """
+        self._check_a11y(YouTubePage)
+
     def _check_a11y(self, page_class):
         """
         Visit the specified page and run accessibility checks on it
         """
         page = page_class(self.browser)
         page.visit()
-        report = page.a11y_audit.check_for_accessibility_errors()
+        # Disabled page elements are exempt from minimum contrast requirements
+        page.a11y_audit.config.set_scope(exclude=['.ln-disabled'])
+        page.a11y_audit.check_for_accessibility_errors()
 
 if __name__ == '__main__':
     unittest.main()

--- a/themes/pytube-201601/static/css/base.css
+++ b/themes/pytube-201601/static/css/base.css
@@ -28,7 +28,7 @@ a {
 /* Custom page footer */
 .footer {
   padding-top: 19px;
-  color: #777;
+  color: #767676;
   border-top: 1px solid #e5e5e5;
 }
 

--- a/themes/pytube-201601/templates/article_list_item_content.html
+++ b/themes/pytube-201601/templates/article_list_item_content.html
@@ -3,7 +3,7 @@
     <a href="{{ SITEURL }}/{{ article.url }}"
        rel="bookmark"
        title="Permalink to {{ article.title|striptags }}">
-      <img class="thumb" src="{{ article.thumbnail_url }}" />
+      <img class="thumb" src="{{ article.thumbnail_url }}" alt="Image from {{ article.title|striptags }}" />
     </a>
   </div>
 

--- a/themes/pytube-201601/templates/article_media.html
+++ b/themes/pytube-201601/templates/article_media.html
@@ -13,7 +13,7 @@
     <div role="tabpanel" class="tab-pane {{ classname }}" id="{{ video.type }}">
         {% if video.tag_type == 'iframe' %}
         <div class="embed-responsive embed-responsive-16by9 videocontainer">
-            <iframe class="embed-responsive-item" src="{{ video.media_url }}" frameborder="0" allowfullscreen></iframe>
+            <iframe class="embed-responsive-item" src="{{ video.media_url }}" title="Video for {{ video.title }}" frameborder="0" allowfullscreen></iframe>
         </div>
         {% elif video.tag_type == 'html5' %}
         <div class="embed-responsive embed-responsive-16by9 videocontainer">

--- a/themes/pytube-201601/templates/index.html
+++ b/themes/pytube-201601/templates/index.html
@@ -8,7 +8,7 @@
         {% for article in articles_page.object_list[:3] %}
           <article>
             <a href="{{ SITEURL }}/{{ article.url }}">
-              <img src="{{ article.thumbnail_url }}" />
+              <img src="{{ article.thumbnail_url }}" alt="Image from {{ article.title|striptags }}" />
             </a>
 
             <section class="details">


### PR DESCRIPTION
Added tests for each type of page currently reachable by browsing the site, and fixed some of the reported issues:

* Increased the contrast of the footer text
* Added missing alt text for some thumbnails
* Added title attribute for video iframes
* Skipped contrast tests for disabled links in the jquery-listnav elements, since the WCAG specification lists disabled UI elements as exempt from the minimum contrast requirement

Three of the tests still fail:

* MP4 video pages are lacking transcripts and optional audio descriptions of the visual elements.  We should probably enable crowdsourcing of these transcripts, I'll write a separate ticket for that.
* OGV video pages have the same issues as MP4 video pages.
* The Google search results have a few accessibility issues.  Not sure we can fix these easily, and we're hoping to use a different search solution in the near future anyway.

The Speakers and Events page tests are pretty slow due to the large number of links on them, but the rest of the tests are relatively fast.