### PR TITLE
Event URLs should use category slugs.

### DIFF
--- a/plugins/event_info.py
+++ b/plugins/event_info.py
@@ -1,12 +1,23 @@
+"""
+This plugin injects as much metadata into the category/event objects
+as possible. Among other things it also manipulates the category's
+slug to reflect the one stored within the category.json file.
+
+That's necessary because each video refers to each event through its name and
+not its slug.
+"""
 import docutils
 import docutils.io
-import io
 import json
+import logging
 
 from pelican.readers import PelicanHTMLTranslator
 from pelican import generators
 from pelican import signals
 from pathlib import Path
+
+
+log = logging.getLogger(__name__)
 
 
 def _generate_html(data):
@@ -28,21 +39,35 @@ def _generate_html(data):
 
 
 def _collect_event_info(generator):
-    collected_metadata = {}
+    events = _load_events()
     if isinstance(generator, generators.ArticlesGenerator):
         for event in [x[0] for x in generator.categories]:
-            event.meta = _load_event_metadata(event.slug)
+            meta = events.get(event.name)
+            # Update the slug of the event with the one provided
+            # by the metadata object.
+            if meta and 'slug' in meta:
+                event.slug = meta['slug']
+            event.meta = meta
 
 
-def _load_event_metadata(slug):
-    path = Path('content') / 'conferences' / slug / 'category.json'
-    if not path.exists():
-        return None
-    with io.open(str(path), encoding='utf-8') as fp:
-        data = json.load(fp)
-        if data['description']:
-            data['description'] = _generate_html(data['description'])
-        return data
+def _load_events():
+    path = Path('content') / 'conferences'
+    events = {}
+    slugs = set()
+    for metafile in path.glob('*/category.json'):
+        with open(str(metafile), encoding='utf-8') as fp:
+            data = json.load(fp)
+            title = data['title']
+            slug = data['slug']
+            if data['description']:
+                data['description'] = _generate_html(data['description'])
+            if title in events:
+                log.critical('{} is not a unique category title!'.format(title))
+            if slug in slugs:
+                log.critical('{} is not a unique slug!'.format(slug))
+            slugs.add(slug)
+            events[title] = data
+    return events
 
 
 def register():


### PR DESCRIPTION
Closes #109. This mostly affects the URLs of the Boston Python Meetup
and DePy 2015. Previously the title of the event was slugified which
in some cases led to different results than using the slug stored within
the event's category.json file.