### PR TITLE
Fix article headers and their levels

### DIFF
--- a/plugins/json_reader.py
+++ b/plugins/json_reader.py
@@ -67,7 +67,7 @@ class JSONReader(BaseReader):
 
     def _get_publisher(self, source, source_file_path):
         # This is a slightly modified copy of `RstReader._get_publisher`
-        extra_params = {'initial_header_level': '2',
+        extra_params = {'initial_header_level': '4',
                         'syntax_highlight': 'short',
                         'input_encoding': 'utf-8',
                         'exit_status_level': 2,
@@ -140,9 +140,9 @@ class JSONReader(BaseReader):
 
         content = []
         for part in ['summary', 'description']:
-            content.append('<h1>{}</h1>'.format(part.title()))
             json_part = json_data.get(part)
             if json_part:
+                content.append('<h3>{}</h3>'.format(part.title()))
                 try:
                     publisher = self._get_publisher(json_part, filename)
                     content.append(publisher.writer.parts.get('body'))

--- a/themes/pytube-201601/templates/article_details.html
+++ b/themes/pytube-201601/templates/article_details.html
@@ -1,5 +1,5 @@
 <div class="details-content">
-  <h2>Details</h2>
+  <h3>Details</h3>
   <ul>
       <li>
         Event:


### PR DESCRIPTION
"Summary" and "Description" should only be shown if there is content to
be rendered below them. Also: The header level should start at h3 as the
video title above is set to h2.