### PR TITLE
Use .url attribute on the tags in article details

### DIFF
--- a/themes/pytube-201601/templates/article_details.html
+++ b/themes/pytube-201601/templates/article_details.html
@@ -19,7 +19,7 @@
         <li>
           Tags:
           {% for tag in article.tags -%}
-            {% if not loop.first %}, {% endif %}<a href="/tag/{{ tag }}">{{ tag }}</a>
+            {% if not loop.first %}, {% endif %}<a href="/tag/{{ tag.url }}">{{ tag }}</a>
           {%- endfor %}
         </li>
       {% endif %}


### PR DESCRIPTION
Makes the URL work properly. Fixes #149 