### PR TITLE
Add a list of the most used tags to the homepage

### DIFF
--- a/plugins/aggregations.py
+++ b/plugins/aggregations.py
@@ -51,6 +51,10 @@ def _inject_aggregates(generator):
         generator.context['latest_categories'] = latest_categories
         generator.context['active_speakers'] = active_speakers
 
+    generator.context['tag_counts'] = sorted([(len(articles), tag)
+                                              for tag, articles in generator.context['tags']],
+                                             reverse=True)
+
 
 def register():
     signals.content_object_init.connect(_handle_content_object_init)

--- a/themes/pytube-201601/templates/index.html
+++ b/themes/pytube-201601/templates/index.html
@@ -65,6 +65,14 @@
             </ul>
             <p><a href="{{ SITE_URL }}/speakers.html">See all speakers...</a></p>
         </section>
+        <section>
+            <h3>Most used tags</h3>
+            <ul>
+            {% for count, tag in tag_counts[:10] %}
+                <li><a href="{{ SITEURL }}/{{ tag.url }}">{{ tag }}<span class="badge">{{ count }}</span></a></li>
+            {% endfor %}
+            </ul>
+        </section>
       </aside></div>
     </div>
   </div>


### PR DESCRIPTION
This is hopefully a bit more discoverable than the big list of tags.

Unfortunately the tags seem to encode information like the conference it's from, author, the fact that it's a talk. Maybe a later task could be to filter out tags that are covered in the Author/Event category by cleaning up the data and deleting the 'talk' tag entirely.

![image](https://cloud.githubusercontent.com/assets/529498/16904635/9c575912-4c67-11e6-801e-db4687744cbb.png)
