### PR TITLE
Fix #150 by making the link actually go to the tag rather than a 404.

### DIFF
--- a/themes/pytube-201601/templates/article_details.html
+++ b/themes/pytube-201601/templates/article_details.html
@@ -19,7 +19,7 @@
         <li>
           Tags:
           {% for tag in article.tags -%}
-            {% if not loop.first %}, {% endif %}<a href="/tag/{{ tag.url }}">{{ tag }}</a>
+            {% if not loop.first %}, {% endif %}<a href="{{ SITEURL }}/{{ tag.url }}">{{ tag }}</a>
           {%- endfor %}
         </li>
       {% endif %}


### PR DESCRIPTION
Erm.. whoops. #150 was just straight up broken. Sorry - Great work on my first commit huh..

Anyway, this fixes it and makes it look like how other links work with the whole `{{ SITEURL }}` thing so hopefully it's better.