### PR TITLE
Render language names instead of codes

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -94,6 +94,25 @@ PLUGINS = [
     'aggregations',
 ]
 
+VIDEO_LANGUAGE_NAMES = {
+    'ita': 'Italian',
+    'zho': 'Chinese',
+    'por': 'Portuguese',
+    'ukr': 'Ukrainian',
+    'deu': 'German',
+    'eng': 'English',
+    'rus': 'Russian',
+    'fra': 'French',
+    'spa': 'Spanish',
+}
+
+def jinja_language_name(code):
+    return VIDEO_LANGUAGE_NAMES.get(code, code)
+
+JINJA_FILTERS = {
+    'language_name': jinja_language_name,
+}
+
 try:
     PR_NUMBER = int(os.environ.get('TRAVIS_PULL_REQUEST'))
 except (TypeError, ValueError):

--- a/themes/pytube-201601/templates/article_details.html
+++ b/themes/pytube-201601/templates/article_details.html
@@ -6,7 +6,7 @@
         <a href="{{ SITEURL }}/{{ article.category.url }}">{{ article.category }}</a>
       </li>
       {% if article.language %}
-        <li>Language: {{ article.language }}</li>
+        <li>Language: {{ article.language|language_name }}</li>
       {% endif %}
       {% if article.videos %}
         <li>
@@ -33,7 +33,6 @@
           </ul>
         </li>
       {% endif %}
- 
+
   </ul>
 </div>
-


### PR DESCRIPTION
After moving from language names to alpha-3 codes within the data
repository we forgot to update the rendering to keep showing the
names. This changes the rendering logic accordingly.