### PR TITLE
Fix two column event display for uneven number of events

### DIFF
--- a/themes/pytube-201601/templates/categories.html
+++ b/themes/pytube-201601/templates/categories.html
@@ -10,7 +10,8 @@
     <nav class="events">
         <div class="col-md-12">
             <div class="row">
-            {% for batch in event_series|batch(event_series|length / 2) %}
+            {% set batch_size=event_series|length / 2 %}
+            {% for batch in event_series|batch(batch_size|round(0, 'ceil')|int) %}
                 <div class="col-md-6 col-sm-12">
                     <ul class="events">
                         {% for event in batch %}


### PR DESCRIPTION
The events page should be batched into two columns. This was broken if there is an uneven number of events due to jinja's `batch` filter not accepting float input.