### PR TITLE
Simplified sizeof utility

### DIFF
--- a/pytube/utils.py
+++ b/pytube/utils.py
@@ -50,7 +50,9 @@ def sizeof(byts):
     """
     sizes = ['bytes', 'KB', 'MB', 'GB', 'TB', 'PB']
     power = int(math.floor(math.log(byts, 1024)))
-    return str(int(byts/float(1024**power)))+' '+(sizes[power] if byts != 1 else 'byte')
+    value = int(byts/float(1024**power))
+    suffix = sizes[power] if byts != 1 else 'byte'
+    return '{0} {1}'.format(value, suffix)
 
 def print_status(progress, file_size, start):
     """

--- a/pytube/utils.py
+++ b/pytube/utils.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 import argparse
 import re
+import math
 
 from os import path
 from sys import stdout

--- a/pytube/utils.py
+++ b/pytube/utils.py
@@ -41,34 +41,15 @@ def safe_filename(text, max_length=200):
     return truncate(filename)
 
 
-def sizeof(bytes):
+def sizeof(byts):
     """Takes the size of file or folder in bytes and returns size formatted in
     KB, MB, GB, TB or PB.
-
-    :params bytes:
+    :params byts:
         Size of the file in bytes
     """
-    alternative = [
-        (1024 ** 5, ' PB'),
-        (1024 ** 4, ' TB'),
-        (1024 ** 3, ' GB'),
-        (1024 ** 2, ' MB'),
-        (1024 ** 1, ' KB'),
-        (1024 ** 0, (' byte', ' bytes')),
-    ]
-
-    for factor, suffix in alternative:
-        if bytes >= factor:
-            break
-    amount = int(bytes / factor)
-    if isinstance(suffix, tuple):
-        singular, multiple = suffix
-        if amount == 1:
-            suffix = singular
-        else:
-            suffix = multiple
-    return "%s%s" % (str(amount), suffix)
-
+    sizes = ['bytes', 'KB', 'MB', 'GB', 'TB', 'PB']
+    power = int(math.floor(math.log(byts, 1024)))
+    return str(int(byts/float(1024**power)))+' '+(sizes[power] if byts != 1 else 'byte')
 
 def print_status(progress, file_size, start):
     """


### PR DESCRIPTION
Shortens the sizeof util to be more concise and efficient. Renames the parameter for sizeof so it does not overwrite the `bytes` function.