### PR TITLE
adding coverage to pytest command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - pip install -r requirements.txt
   - pip install -r tests/requirements.txt
 before_script: flake8
-script: pytest
+script: pytest --cov=pytube
 sudo: required
 after_success:
   coveralls


### PR DESCRIPTION
re-enables collection of coverage data, so coveralls can run successfully again.

Refs #154 