### PR TITLE
Fix specifying filename issue

### DIFF
--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -173,21 +173,29 @@ class Stream(object):
         filename = safe_filename(title)
         return '{filename}.{s.subtype}'.format(filename=filename, s=self)
 
-    def download(self, output_path=None):
+    def download(self, output_path=None, filename=None):
         """Write the media stream to disk.
 
         :param output_path:
             (optional) Output path for writing media file. If one is not
             specified, defaults to the current working directory.
         :type output_path: str or None
+        :param filename:
+            (optional) Output filename (stem only) for writing media file.
+            If one is not specified, the default filename is used.
+        :type filename: str or None
+
         :rtype: None
 
         """
-        # TODO(nficano): allow a filename to specified.
         output_path = output_path or os.getcwd()
+        if filename:
+            safe = safe_filename(filename)
+            filename = '{filename}.{s.subtype}'.format(filename=safe, s=self)
+        filename = filename or self.default_filename
 
         # file path
-        fp = os.path.join(output_path, self.default_filename)
+        fp = os.path.join(output_path, filename)
         bytes_remaining = self.filesize
         logger.debug(
             'downloading (%s total bytes) file to %s',


### PR DESCRIPTION
I've added another optional arg to `Stream.download()` to specify the filename. I assumed just the filename stem will be provided, and so the extension is still deduced from the stream's MIME type. Not sure if having two optional args (`output_path` and `filename`) is the best way to go though. Thoughts/comments greatly appreciated, thanks :-)