### PR TITLE
fix removing " from output_path when using Copy as Path in Windows

### DIFF
--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -173,29 +173,30 @@ class Stream(object):
         filename = safe_filename(title)
         return '{filename}.{s.subtype}'.format(filename=filename, s=self)
 
-    def download(self, output_path=None, filename=None):
+    def download(self, output_path=None):
         """Write the media stream to disk.
 
         :param output_path:
             (optional) Output path for writing media file. If one is not
             specified, defaults to the current working directory.
         :type output_path: str or None
-        :param filename:
-            (optional) Output filename (stem only) for writing media file.
-            If one is not specified, the default filename is used.
-        :type filename: str or None
-
         :rtype: None
 
         """
+        # TODO(nficano): allow a filename to specified.
         output_path = output_path or os.getcwd()
-        if filename:
-            safe = safe_filename(filename)
-            filename = '{filename}.{s.subtype}'.format(filename=safe, s=self)
-        filename = filename or self.default_filename
+
+        # remove " from output_path.
+        output_path=list(output_path)
+        try:
+            while(1):
+                output_path.remove('"')
+        except ValueError:
+            pass
+        output_path=''.join(output_path)
 
         # file path
-        fp = os.path.join(output_path, filename)
+        fp = os.path.join(output_path, self.default_filename)
         bytes_remaining = self.filesize
         logger.debug(
             'downloading (%s total bytes) file to %s',


### PR DESCRIPTION
Added code for removing quotation marks when using "Copy as Path" in Windows by SHIFT+right clicking on any folder for the full folder path.