### PR TITLE
fix by removing " when entered pathname has "

### DIFF
--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -193,7 +193,17 @@ class Stream(object):
             safe = safe_filename(filename)
             filename = '{filename}.{s.subtype}'.format(filename=safe, s=self)
         filename = filename or self.default_filename
-
+        
+        # remove " from output_path.
+        output_path=list(output_path)
+        if(output_path!=None):
+            try:
+                while(1):
+                    output_path.remove('"')
+            except ValueError:
+                pass
+            output_path=''.join(output_path)
+            
         # file path
         fp = os.path.join(output_path, filename)
         bytes_remaining = self.filesize


### PR DESCRIPTION
Many a times, the pathname can have " when path is copied by "Copy as Path" in Windows or even in other circumstances.
To avoid errors arising from " altogether, I have added code to remove " from entered pathname (i.e. destination path).