### PR TITLE
fix issue 217 by adding contrib to setup.py file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     version='9.0.5',
     author='Nick Ficano',
     author_email='nficano@gmail.com',
-    packages=['pytube'],
+    packages=['pytube', 'pytube.contrib'],
     url='https://github.com/nficano/pytube',
     license=license,
     entry_points={


### PR DESCRIPTION
without fix:

>>> import pytube
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "c:\python27\lib\site-packages\pytube\__init__.py", line 22, in <module>
    from pytube.contrib.playlist import Playlist
ImportError: No module named contrib.playlist

with fix:
python .\setup.py install

Python 2.7.13 (v2.7.13:a06454b1afa1, Dec 17 2016, 20:53:40) [MSC v.1500 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import pytube
>>> pytube.__version__
'9.0.5'
