### PR TITLE
Feature: cache contents of base.js from identical urls

### DIFF
--- a/pytube/__main__.py
+++ b/pytube/__main__.py
@@ -19,6 +19,7 @@ from pytube import mixins
 from pytube import request
 from pytube import Stream
 from pytube import StreamQuery
+from pytube.cache import get_js
 from pytube.compat import parse_qsl
 from pytube.helpers import apply_mixin
 
@@ -158,7 +159,7 @@ class YouTube(object):
         self.vid_info = request.get(self.vid_info_url)
         if not self.age_restricted:
             self.js_url = extract.js_url(self.watch_html)
-            self.js = request.get(self.js_url)
+            self.js = get_js(self.js_url)
 
     def initialize_stream_objects(self, fmt):
         """Convert manifest data to instances of :class:`Stream <Stream>`.

--- a/pytube/cache.py
+++ b/pytube/cache.py
@@ -4,6 +4,7 @@ from functools import lru_cache
 
 from pytube import request
 
+
 @lru_cache(maxsize=None)
 def get_js(js_url):
     """Retrieve Javascript from js_url if Javascript is not already cached.

--- a/pytube/cache.py
+++ b/pytube/cache.py
@@ -1,7 +1,17 @@
+# -*- coding: utf-8 -*-
+"""Minimize requests for base.js when looking to the same URL"""
 from functools import lru_cache
 
 from pytube import request
 
 @lru_cache(maxsize=None)
 def get_js(js_url):
+    """Retrieve Javascript from js_url if Javascript is not already cached.
+
+    :param str js_url:
+        A YouTube url for the base.js asset file.
+    :rtype: str
+    :returns:
+        The contents of the base.js asset file.
+    """
     return request.get(js_url)

--- a/pytube/cache.py
+++ b/pytube/cache.py
@@ -1,0 +1,7 @@
+from functools import lru_cache
+
+from pytube import request
+
+@lru_cache(maxsize=None)
+def get_js(js_url):
+    return request.get(js_url)


### PR DESCRIPTION
YouTube appears to serve base.js from the same URL pretty often. This should cut down on the number of requests we're making for the same resource when downloading more than a single video.