### PR TITLE
Stream video to buffer

### DIFF
--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -215,7 +215,7 @@ class Stream(object):
         """Write the media stream to buffer
 
         :rtype: io.BytesIO buffer
-        """ 
+        """
         buffer = io.BytesIO()
         bytes_remaining = self.filesize
         logger.debug(
@@ -230,7 +230,6 @@ class Stream(object):
             self.on_progress(chunk, buffer, bytes_remaining)
         self.on_complete(buffer)
         return buffer
-
 
     def on_progress(self, chunk, file_handler, bytes_remaining):
         """On progress callback function.

--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -212,17 +212,24 @@ class Stream(object):
             self.on_complete(fh)
 
     def stream_to_buffer(self):
-       """Write the media stream to buffer
-       :rtype: io.BytesIO buffer
-       """
-       bytes_remaining = self.filesize   
-       buffer = io.BytesIO()
+        """Write the media stream to buffer
 
-       for chunk in request.get(self.url, streaming=True):
-           bytes_remaining -= len(chunk)
-           buffer.write(chunk)
+        :rtype: io.BytesIO buffer
+        """ 
+        buffer = io.BytesIO()
+        bytes_remaining = self.filesize
+        logger.debug(
+            'downloading (%s total bytes) file to BytesIO buffer',
+            self.filesize,
+        )
 
-       return buffer
+        for chunk in request.get(self.url, streaming=True):
+            # reduce the (bytes) remainder by the length of the chunk.
+            bytes_remaining -= len(chunk)
+            # send to the on_progress callback.
+            self.on_progress(chunk, buffer, bytes_remaining)
+        self.on_complete(buffer)
+        return buffer
 
 
     def on_progress(self, chunk, file_handler, bytes_remaining):

--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -9,6 +9,7 @@ separately).
 """
 from __future__ import absolute_import
 
+import io
 import logging
 import os
 import pprint
@@ -209,6 +210,20 @@ class Stream(object):
                 # send to the on_progress callback.
                 self.on_progress(chunk, fh, bytes_remaining)
             self.on_complete(fh)
+
+    def stream_to_buffer(self):
+       """Write the media stream to buffer
+       :rtype: io.BytesIO buffer
+       """
+       bytes_remaining = self.filesize   
+       buffer = io.BytesIO()
+
+       for chunk in request.get(self.url, streaming=True):
+           bytes_remaining -= len(chunk)
+           buffer.write(chunk)
+
+       return buffer
+
 
     def on_progress(self, chunk, file_handler, bytes_remaining):
         """On progress callback function.


### PR DESCRIPTION
I've added a function to stream video data to a buffer. 
`Stream.stream_to_buffer()` will save all video data in an `io.BytesIO` object instead of a file. 
I find this useful when I do post processing on videos. 
