### PR TITLE
added autonumbering for playlists

### DIFF
--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -66,12 +66,25 @@ class Playlist(object):
             complete_url = base_url + video_id
             self.video_urls.append(complete_url)
 
-    def download_all(self, download_path=None, prefix_number=True):
+    def download_all(self, download_path=None, prefix_number=True, reverse_numbering=False):
         """Download all the videos in the the playlist. Initially, download
         resolution is 720p (or highest available), later more option
         should be added to download resolution of choice
 
         TODO(nficano): Add option to download resolution of user's choice
+
+        :param download_path:
+            (optional) Output path for the playlist If one is not
+            specified, defaults to the current working directory.
+            This is passed along to the Stream objects.
+        :type download_path: str or None
+        :param prefix_number:
+            (optional) Automatically numbers
+        :type prefix_number: bool
+        :param reverse_numbering:
+            (optional) Lets you number playlists in reverse, since some
+            playlists are ordered newest -> oldests.
+        :type reverse_numbering: bool
         """
 
         def path_num_prefix_generator():
@@ -86,14 +99,21 @@ class Playlist(object):
             :return: prefix: string
             """
             digits = len(str(len(self.video_urls)))
-            i = 1
+            reverse = reverse_numbering
+            if reverse:
+                i = len(self.video_urls)
+            else:
+                i = 1
             while True:
                 prefix = str(i)
                 if len(prefix) < digits:
                     for _ in range(digits - len(prefix)):
                         prefix = "0" + prefix
                 prefix += " "
-                i += 1
+                if reverse:
+                    i -= 1
+                else:
+                    i += 1
                 yield prefix
 
         self.populate_video_urls()

--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -84,7 +84,6 @@ class Playlist(object):
             start, stop, step = (1, len(self.video_urls) + 1, 1)
         return (str(i).zfill(digits) for i in range(start, stop, step))
 
-
     def download_all(self, download_path=None, prefix_number=True,
                      reverse_numbering=False):
         """Download all the videos in the the playlist. Initially, download

--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -66,6 +66,35 @@ class Playlist(object):
             complete_url = base_url + video_id
             self.video_urls.append(complete_url)
 
+    def _path_num_prefix_generator(self, reverse_numbering=False):
+        """
+        This generator function generates number prefixes, for the items
+        in the playlist.
+        If the number of digits required to name a file,is less than is
+        required to name the last file,it prepends 0s.
+        So if you have a playlist of 100 videos it will number them like:
+        001, 002, 003 ect, up to 100.
+        It also adds a space after the number.
+        :return: prefix: string
+        """
+        digits = len(str(len(self.video_urls)))
+        reverse = reverse_numbering
+        if reverse:
+            i = len(self.video_urls)
+        else:
+            i = 1
+        while True:
+            prefix = str(i)
+            if len(prefix) < digits:
+                for _ in range(digits - len(prefix)):
+                    prefix = "0" + prefix
+            prefix += " "
+            if reverse:
+                i -= 1
+            else:
+                i += 1
+            yield prefix
+
     def download_all(self, download_path=None, prefix_number=True,
                      reverse_numbering=False):
         """Download all the videos in the the playlist. Initially, download
@@ -81,7 +110,7 @@ class Playlist(object):
         :type download_path: str or None
         :param prefix_number:
             (optional) Automatically numbers playlists using the
-            path_num_prefix_generator function.
+            _path_num_prefix_generator function.
         :type prefix_number: bool
         :param reverse_numbering:
             (optional) Lets you number playlists in reverse, since some
@@ -89,40 +118,11 @@ class Playlist(object):
         :type reverse_numbering: bool
         """
 
-        def path_num_prefix_generator():
-            """
-            This generator function generates number prefixes, for the items
-            in the playlist.
-            If the number of digits required to name a file,is less than is
-            required to name the last file,it prepends 0s.
-            So if you have a playlist of 100 videos it will number them like:
-            001, 002, 003 ect, up to 100.
-            It also adds a space after the number.
-            :return: prefix: string
-            """
-            digits = len(str(len(self.video_urls)))
-            reverse = reverse_numbering
-            if reverse:
-                i = len(self.video_urls)
-            else:
-                i = 1
-            while True:
-                prefix = str(i)
-                if len(prefix) < digits:
-                    for _ in range(digits - len(prefix)):
-                        prefix = "0" + prefix
-                prefix += " "
-                if reverse:
-                    i -= 1
-                else:
-                    i += 1
-                yield prefix
-
         self.populate_video_urls()
         logger.debug('total videos found: ', len(self.video_urls))
         logger.debug('starting download')
 
-        prefix_gen = path_num_prefix_generator()
+        prefix_gen = self._path_num_prefix_generator(reverse_numbering)
 
         for link in self.video_urls:
             yt = YouTube(link)

--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -115,7 +115,6 @@ class Playlist(object):
 
         for link in self.video_urls:
             yt = YouTube(link)
-
             # TODO: this should not be hardcoded to a single user's preference
             dl_stream = yt.streams.filter(
                 progressive=True, subtype='mp4',

--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -76,8 +76,11 @@ class Playlist(object):
 
         def path_num_prefix_generator():
             """
-            This generator function generates number prefixes for the items in the playlist.
-            If you have a playlist of 100 videos it will number them like this:
+            This generator function generates number prefixes, for the items
+            in the playlist.
+            If the number of digits required to name a file,is less than is
+            required to name the last file,it prepends 0s.
+            So if you have a playlist of 100 videos it will number them like:
             001, 002, 003 ect, up to 100.
             It also adds a space after the number.
             :return: prefix: string

--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -66,7 +66,7 @@ class Playlist(object):
             complete_url = base_url + video_id
             self.video_urls.append(complete_url)
 
-    def _path_num_prefix_generator(self, reverse_numbering=False):
+    def _path_num_prefix_generator(self, reverse=False):
         """
         This generator function generates number prefixes, for the items
         in the playlist.
@@ -75,25 +75,15 @@ class Playlist(object):
         So if you have a playlist of 100 videos it will number them like:
         001, 002, 003 ect, up to 100.
         It also adds a space after the number.
-        :return: prefix: string
+        :return: prefix string generator : generator
         """
         digits = len(str(len(self.video_urls)))
-        reverse = reverse_numbering
         if reverse:
-            i = len(self.video_urls)
+            start, stop, step = (len(self.video_urls), 0, -1)
         else:
-            i = 1
-        while True:
-            prefix = str(i)
-            if len(prefix) < digits:
-                for _ in range(digits - len(prefix)):
-                    prefix = "0" + prefix
-            prefix += " "
-            if reverse:
-                i -= 1
-            else:
-                i += 1
-            yield prefix
+            start, stop, step = (1, len(self.video_urls) + 1, 1)
+        return (str(i).zfill(digits) for i in range(start, stop, step))
+
 
     def download_all(self, download_path=None, prefix_number=True,
                      reverse_numbering=False):

--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -66,7 +66,7 @@ class Playlist(object):
             complete_url = base_url + video_id
             self.video_urls.append(complete_url)
 
-    def download_all(self, download_path=None, file_number_prefix=True):
+    def download_all(self, download_path=None, prefix_number=True):
         """Download all the videos in the the playlist. Initially, download
         resolution is 720p (or highest available), later more option
         should be added to download resolution of choice
@@ -90,7 +90,7 @@ class Playlist(object):
             while True:
                 prefix = str(i)
                 if len(prefix) < digits:
-                    for f in range(digits - len(prefix)):
+                    for _ in range(digits - len(prefix)):
                         prefix = "0" + prefix
                 prefix += " "
                 i += 1

--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -79,7 +79,8 @@ class Playlist(object):
             This is passed along to the Stream objects.
         :type download_path: str or None
         :param prefix_number:
-            (optional) Automatically numbers
+            (optional) Automatically numbers playlists using the
+            path_num_prefix_generator function.
         :type prefix_number: bool
         :param reverse_numbering:
             (optional) Lets you number playlists in reverse, since some

--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -111,7 +111,7 @@ class Playlist(object):
             ).order_by('resolution').desc().first()
 
             logger.debug('download path: %s', download_path)
-            if file_number_prefix:
+            if prefix_number:
                 prefix = next(prefix_gen)
                 logger.debug('file prefix is: %s', prefix)
                 dl_stream.download(download_path, filename_prefix=prefix)

--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -66,7 +66,8 @@ class Playlist(object):
             complete_url = base_url + video_id
             self.video_urls.append(complete_url)
 
-    def download_all(self, download_path=None, prefix_number=True, reverse_numbering=False):
+    def download_all(self, download_path=None, prefix_number=True,
+                     reverse_numbering=False):
         """Download all the videos in the the playlist. Initially, download
         resolution is 720p (or highest available), later more option
         should be added to download resolution of choice

--- a/pytube/exceptions.py
+++ b/pytube/exceptions.py
@@ -34,4 +34,3 @@ class ExtractError(PytubeError):
 
 class RegexMatchError(ExtractError):
     """Regex pattern did not return any matches."""
-

--- a/pytube/exceptions.py
+++ b/pytube/exceptions.py
@@ -34,3 +34,4 @@ class ExtractError(PytubeError):
 
 class RegexMatchError(ExtractError):
     """Regex pattern did not return any matches."""
+

--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -174,7 +174,7 @@ class Stream(object):
         filename = safe_filename(title)
         return '{filename}.{s.subtype}'.format(filename=filename, s=self)
 
-    def download(self, output_path=None, filename=None):
+    def download(self, output_path=None, filename=None, filename_prefix=None):
         """Write the media stream to disk.
 
         :param output_path:
@@ -185,6 +185,12 @@ class Stream(object):
             (optional) Output filename (stem only) for writing media file.
             If one is not specified, the default filename is used.
         :type filename: str or None
+        :param filename_prefix:
+            (optional) A string that will be prepended to the filename.
+            For example a number in a playlist or the name of a series.
+            If one is not specified, nothing will be prepended
+            Seperate from filename so you can use default and still add a prefix.
+        :type filename_prefix: str or None
 
         :rtype: None
 
@@ -194,6 +200,9 @@ class Stream(object):
             safe = safe_filename(filename)
             filename = '{filename}.{s.subtype}'.format(filename=safe, s=self)
         filename = filename or self.default_filename
+
+        if filename_prefix:
+            filename = safe_filename("{prefix}{filename}".format(prefix=filename_prefix, filename=filename))
 
         # file path
         fp = os.path.join(output_path, filename)

--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -203,9 +203,9 @@ class Stream(object):
         filename = filename or self.default_filename
 
         if filename_prefix:
-            new_name = "{prefix}{filename}"\
-                .format(prefix=filename_prefix, filename=filename)
-            filename = safe_filename(new_name)
+            filename = "{prefix}{filename}"\
+                .format(prefix=safe_filename(filename_prefix),
+                        filename=filename)
 
         # file path
         fp = os.path.join(output_path, filename)

--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -189,7 +189,8 @@ class Stream(object):
             (optional) A string that will be prepended to the filename.
             For example a number in a playlist or the name of a series.
             If one is not specified, nothing will be prepended
-            Seperate from filename so you can use default and still add a prefix.
+            This is seperate from filename so you can use the default
+            filename but still add a prefix.
         :type filename_prefix: str or None
 
         :rtype: None
@@ -202,7 +203,9 @@ class Stream(object):
         filename = filename or self.default_filename
 
         if filename_prefix:
-            filename = safe_filename("{prefix}{filename}".format(prefix=filename_prefix, filename=filename))
+            new_name = "{prefix}{filename}"\
+                .format(prefix=filename_prefix, filename=filename)
+            filename = safe_filename(new_name)
 
         # file path
         fp = os.path.join(output_path, filename)

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
 from pytube import Playlist
 
+short_test_pl = 'https://www.youtube.com/watch?v=' \
+          'm5q2GCsteQs&list=PL525f8ds9RvsXDl44X6Wwh9t3fCzFNApw'
+long_test_pl = "https://www.youtube.com/watch?v=" \
+               "9CHDoAsX1yo&list=UUXuqSBlHAE6Xw-yeJA0Tunw"
+
 
 def test_construct():
-    ob = Playlist(
-        'https://www.youtube.com/watch?v=m5q2GCsteQs&list='
-        'PL525f8ds9RvsXDl44X6Wwh9t3fCzFNApw',
-    )
+    ob = Playlist(short_test_pl)
     expected = 'https://www.youtube.com/' \
                'playlist?list=' \
                'PL525f8ds9RvsXDl44X6Wwh9t3fCzFNApw'
@@ -15,10 +17,7 @@ def test_construct():
 
 
 def test_link_parse():
-    ob = Playlist(
-        'https://www.youtube.com/watch?v=m5q2GCsteQs&list='
-        'PL525f8ds9RvsXDl44X6Wwh9t3fCzFNApw',
-    )
+    ob = Playlist(short_test_pl)
 
     expected = [
         '/watch?v=m5q2GCsteQs',
@@ -29,10 +28,7 @@ def test_link_parse():
 
 
 def test_populate():
-    ob = Playlist(
-        'https://www.youtube.com/watch?v=m5q2GCsteQs&list='
-        'PL525f8ds9RvsXDl44X6Wwh9t3fCzFNApw',
-    )
+    ob = Playlist(short_test_pl)
     expected = [
         'https://www.youtube.com/watch?v=m5q2GCsteQs',
         'https://www.youtube.com/watch?v=5YK63cXyJ2Q',
@@ -44,11 +40,38 @@ def test_populate():
 
 
 def test_download():
-    ob = Playlist(
-        'https://www.youtube.com/watch?v=lByG_AgKS9k&list='
-        'PL525f8ds9RvuerPZ3bZygmNiYw2sP4BDk',
-    )
+    ob = Playlist(short_test_pl)
     ob.download_all()
     ob.download_all('.')
     ob.download_all(prefix_number=False)
     ob.download_all('.', prefix_number=False)
+
+
+def test_numbering():
+    ob = Playlist(short_test_pl)
+    ob.populate_video_urls()
+    gen = ob._path_num_prefix_generator(reverse_numbering=False)
+    assert "1" in next(gen)
+    assert "2" in next(gen)
+
+    ob = Playlist(short_test_pl)
+    ob.populate_video_urls()
+    gen = ob._path_num_prefix_generator(reverse_numbering=True)
+    assert str(len(ob.video_urls)) in next(gen)
+    assert str(len(ob.video_urls) - 1) in next(gen)
+
+    ob = Playlist(long_test_pl)
+    ob.populate_video_urls()
+    gen = ob._path_num_prefix_generator(reverse_numbering=False)
+    nxt = next(gen)
+    assert len(nxt) > 1
+    assert "1" in nxt
+    nxt = next(gen)
+    assert len(nxt) > 1
+    assert "2" in nxt
+
+    ob = Playlist(long_test_pl)
+    ob.populate_video_urls()
+    gen = ob._path_num_prefix_generator(reverse_numbering=True)
+    assert str(len(ob.video_urls)) in next(gen)
+    assert str(len(ob.video_urls) - 1) in next(gen)

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -50,3 +50,5 @@ def test_download():
     )
     ob.download_all()
     ob.download_all('.')
+    ob.download_all(prefix_number=False)
+    ob.download_all('.', prefix_number=False)

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -16,17 +16,6 @@ def test_construct():
     assert ob.construct_playlist_url() == expected
 
 
-def test_link_parse():
-    ob = Playlist(short_test_pl)
-
-    expected = [
-        '/watch?v=m5q2GCsteQs',
-        '/watch?v=5YK63cXyJ2Q',
-        '/watch?v=Rzt4rUPFYD4',
-    ]
-    assert ob.parse_links() == expected
-
-
 def test_populate():
     ob = Playlist(short_test_pl)
     expected = [
@@ -37,6 +26,17 @@ def test_populate():
 
     ob.populate_video_urls()
     assert ob.video_urls == expected
+
+
+def test_link_parse():
+    ob = Playlist(short_test_pl)
+
+    expected = [
+        '/watch?v=m5q2GCsteQs',
+        '/watch?v=5YK63cXyJ2Q',
+        '/watch?v=Rzt4rUPFYD4',
+    ]
+    assert ob.parse_links() == expected
 
 
 def test_download():
@@ -50,19 +50,19 @@ def test_download():
 def test_numbering():
     ob = Playlist(short_test_pl)
     ob.populate_video_urls()
-    gen = ob._path_num_prefix_generator(reverse_numbering=False)
+    gen = ob._path_num_prefix_generator(reverse=False)
     assert "1" in next(gen)
     assert "2" in next(gen)
 
     ob = Playlist(short_test_pl)
     ob.populate_video_urls()
-    gen = ob._path_num_prefix_generator(reverse_numbering=True)
+    gen = ob._path_num_prefix_generator(reverse=True)
     assert str(len(ob.video_urls)) in next(gen)
     assert str(len(ob.video_urls) - 1) in next(gen)
 
     ob = Playlist(long_test_pl)
     ob.populate_video_urls()
-    gen = ob._path_num_prefix_generator(reverse_numbering=False)
+    gen = ob._path_num_prefix_generator(reverse=False)
     nxt = next(gen)
     assert len(nxt) > 1
     assert "1" in nxt
@@ -72,6 +72,6 @@ def test_numbering():
 
     ob = Playlist(long_test_pl)
     ob.populate_video_urls()
-    gen = ob._path_num_prefix_generator(reverse_numbering=True)
+    gen = ob._path_num_prefix_generator(reverse=True)
     assert str(len(ob.video_urls)) in next(gen)
     assert str(len(ob.video_urls) - 1) in next(gen)


### PR DESCRIPTION
Added optional automatic numbering of the files created by Playlisl.download_all.

This is done by using a generator function that yields a filename prefix, which is passed to Stream.download.