### PR TITLE
Add proxy support.

### DIFF
--- a/pytube/__main__.py
+++ b/pytube/__main__.py
@@ -22,6 +22,7 @@ from pytube import StreamQuery
 from pytube.compat import parse_qsl
 from pytube.exceptions import VideoUnavailable
 from pytube.helpers import apply_mixin
+from pytube.compat import install_proxy
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +32,7 @@ class YouTube(object):
 
     def __init__(
         self, url=None, defer_prefetch_init=False, on_progress_callback=None,
-        on_complete_callback=None,
+        on_complete_callback=None, proxies=None,
     ):
         """Construct a :class:`YouTube <YouTube>`.
 
@@ -79,6 +80,9 @@ class YouTube(object):
             'on_progress': on_progress_callback,
             'on_complete': on_complete_callback,
         }
+
+        if proxies:
+            install_proxy(proxies)
 
         if not defer_prefetch_init:
             self.prefetch_init()

--- a/pytube/compat.py
+++ b/pytube/compat.py
@@ -10,6 +10,7 @@ PY33 = sys.version_info[0:2] >= (3, 3)
 
 
 if PY2:
+    import urllib2
     from urllib import urlencode
     from urllib2 import URLError
     from urllib2 import quote
@@ -17,6 +18,17 @@ if PY2:
     from urllib2 import urlopen
     from urlparse import parse_qsl
     from HTMLParser import HTMLParser
+
+    def install_proxy(proxy_handler):
+        """
+        install global proxy.
+        :param proxy_handler:
+            :samp:`{"http":"http://my.proxy.com:1234", "https":"https://my.proxy.com:1234"}`
+        :return:
+        """
+        proxy_support = urllib2.ProxyHandler(proxy_handler)
+        opener = urllib2.build_opener(proxy_support)
+        urllib2.install_opener(opener)
 
     def unescape(s):
         """Strip HTML entries from a string."""
@@ -34,6 +46,12 @@ elif PY3:
     from urllib.parse import unquote
     from urllib.parse import urlencode
     from urllib.request import urlopen
+    from urllib import request
+
+    def install_proxy(proxy_handler):
+        proxy_support = request.ProxyHandler(proxy_handler)
+        opener = request.build_opener(proxy_support)
+        request.install_opener(opener)
 
     def unicode(s):
         """No-op."""


### PR DESCRIPTION
- add proxy option for YouTube, install a global proxy for urllib.
- compatible with both py27 urllib2 and py35 urllib
- example: yt = YouTube(url, proxies={"http":"http://my.proxy.com:1234"})