### PR TITLE
Fix ordering problems when trying to sort numerical values as string

### DIFF
--- a/pytube/query.py
+++ b/pytube/query.py
@@ -163,14 +163,17 @@ class StreamQuery:
             The name of the attribute to sort by.
         """
 
-        numerical_attr_repr = {}
+        integer_attr_repr = {}
         for stream in self.fmt_streams:
             attr = getattr(stream, attribute_name)
+            if attr is None:
+                break
             num = [char for char in attr if char.isdigit()]
-            numerical_attr_repr[attr] = int(''.join(num)) if num else None
+            integer_attr_repr[attr] = int(''.join(num)) if num else None
 
-        if all(numerical_attr_repr.values()):
-            key = lambda s: numerical_attr_repr[getattr(s, attribute_name)]
+        # if every attribute has an integer representation
+        if all(integer_attr_repr.values()) and integer_attr_repr:
+            key = lambda s: integer_attr_repr[getattr(s, attribute_name)]
         else:
             key=lambda s: getattr(s, attribute_name)
 

--- a/pytube/query.py
+++ b/pytube/query.py
@@ -130,14 +130,14 @@ class StreamQuery:
         if only_audio:
             filters.append(
                 lambda s: (
-                    s.includes_audio_track and not s.includes_video_track
+                        s.includes_audio_track and not s.includes_video_track
                 ),
             )
 
         if only_video:
             filters.append(
                 lambda s: (
-                    s.includes_video_track and not s.includes_audio_track
+                        s.includes_video_track and not s.includes_audio_track
                 ),
             )
 
@@ -157,14 +157,26 @@ class StreamQuery:
         return StreamQuery(fmt_streams)
 
     def order_by(self, attribute_name):
-        """Apply a sort order to a resultset.
+        """Apply a sort order to a result set.
 
         :param str attribute_name:
             The name of the attribute to sort by.
         """
+
+        numerical_attr_repr = {}
+        for stream in self.fmt_streams:
+            attr = getattr(stream, attribute_name)
+            num = [char for char in attr if char.isdigit()]
+            numerical_attr_repr[attr] = int(''.join(num)) if num else None
+
+        if all(numerical_attr_repr.values()):
+            key = lambda s: numerical_attr_repr[getattr(s, attribute_name)]
+        else:
+            key=lambda s: getattr(s, attribute_name)
+
         fmt_streams = sorted(
             self.fmt_streams,
-            key=lambda s: getattr(s, attribute_name),
+            key=key
         )
         return StreamQuery(fmt_streams)
 

--- a/sort_by_num.py
+++ b/sort_by_num.py
@@ -1,4 +1,0 @@
-from pytube import YouTube
-
-yt = YouTube('https://www.youtube.com/watch?v=5cvM-crlDvg')
-print(yt.streams.filter(only_audio=True).order_by('abr').all())

--- a/sort_by_num.py
+++ b/sort_by_num.py
@@ -1,0 +1,4 @@
+from pytube import YouTube
+
+yt = YouTube('https://www.youtube.com/watch?v=5cvM-crlDvg')
+print(yt.streams.filter(only_audio=True).order_by('abr').all())


### PR DESCRIPTION
Should fix #194 and #252. 

Need input on wether or not we should `raise` if the `attr` they are requesting to sort is `None`, because if we don't, this cryptic error will be raised:
@nficano 
```
TypeError: 'NoneType' object is not iterable

```