### PR TITLE
Suppress exception while downloading Playlist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ _templates
 _autosummary
 
 .pytest_cache*
+
+# IDE Files
+.idea/


### PR DESCRIPTION
This commit adds an option to suppress exception when downloading a video in a playlist ( i.e Video Unavailable ). This way rest of the playlist still continues to be downloaded instead of breaking up in the middle of the download process