### PR TITLE
fixed bug that caused on_complete to fail

### DIFF
--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -226,7 +226,7 @@ class Stream(object):
                 bytes_remaining -= len(chunk)
                 # send to the on_progress callback.
                 self.on_progress(chunk, fh, bytes_remaining)
-            self.on_complete(fh)
+        self.on_complete(fh)
         return fp
 
     def stream_to_buffer(self):


### PR DESCRIPTION
There was an indentation error that prevented the downloaded file from closing before calling the on_complete callback.