### PR TITLE
Add YouTube.published_date feature

### DIFF
--- a/pytube/__main__.py
+++ b/pytube/__main__.py
@@ -118,6 +118,7 @@ class YouTube(object):
             )['args']
 
         self.vid_descr = extract.get_vid_descr(self.watch_html)
+        self.vid_published_date = extract.get_vid_published_date(self.watch_html)
         # https://github.com/nficano/pytube/issues/165
         stream_maps = ['url_encoded_fmt_stream_map']
         if 'adaptive_fmts' in self.player_config_args:
@@ -261,6 +262,15 @@ class YouTube(object):
 
         """
         return self.vid_descr
+
+    @property
+    def published_date(self):
+        """Get the published date.
+
+        :rtype: :class:`datetime.date`
+
+        """
+        return self.vid_published_date
 
     @property
     def rating(self):

--- a/pytube/extract.py
+++ b/pytube/extract.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """This module contains all non-cipher related data extraction logic."""
 import json
+import datetime as dt
 from collections import OrderedDict
 
 from pytube.compat import HTMLParser
@@ -13,12 +14,16 @@ from pytube.helpers import regex_search
 class PytubeHTMLParser(HTMLParser):
     in_vid_descr = False
     vid_descr = ''
+    vid_published_date = None
 
     def handle_starttag(self, tag, attrs):
         if tag == 'p':
             for attr in attrs:
                 if attr[0] == 'id' and attr[1] == 'eow-description':
                     self.in_vid_descr = True
+        if tag == 'meta':
+            if attrs[0] == ('itemprop', 'datePublished'):
+                self.vid_published_date = dt.datetime.strptime(attrs[1][1], '%Y-%m-%d').date()
 
     def handle_endtag(self, tag):
         if tag == 'p' and self.in_vid_descr:
@@ -199,3 +204,8 @@ def get_vid_descr(html):
     html_parser = PytubeHTMLParser()
     html_parser.feed(html)
     return html_parser.vid_descr
+	
+def get_vid_published_date(html):
+    html_parser = PytubeHTMLParser()
+    html_parser.feed(html)
+    return html_parser.vid_published_date

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Unit tests for the :module:`extract <extract>` module."""
 from pytube import extract
-
+import datetime as dt
 
 def test_extract_video_id():
     url = 'https://www.youtube.com/watch?v=9bZkp7q19f0'
@@ -48,3 +48,7 @@ def test_non_age_restricted(cipher_signature):
 def test_get_vid_desc(cipher_signature):
     expected = "PSY - DADDY(feat. CL of 2NE1) M/V @ https://youtu.be/FrG4TEcSuRgPSY - 나팔바지(NAPAL BAJI) M/V @ https://youtu.be/tF27TNC_4pcPSY - 7TH ALBUM '칠집싸이다' on iTunes @ http://smarturl.it/PSY_7THALBUMPSY - GANGNAM STYLE(강남스타일) on iTunes @ http://smarturl.it/PsyGangnam#PSY #싸이 #GANGNAMSTYLE #강남스타일More about PSY@http://www.psypark.com/http://www.youtube.com/officialpsyhttp://www.facebook.com/officialpsyhttp://twitter.com/psy_oppahttps://www.instagram.com/42psy42http://iTunes.com/PSYhttp://sptfy.com/PSYhttp://weibo.com/psyoppahttp://twitter.com/ygent_official"  # noqa
     assert extract.get_vid_descr(cipher_signature.watch_html) == expected
+
+def test_get_vid_published_date(cipher_signature):
+    expected = dt.datetime(2012, 7, 15).date()
+    assert extract.get_vid_published_date(cipher_signature.watch_html) == expected


### PR DESCRIPTION
Add extract.get_vid_published_date and YouTube.published_date feature.
We can get the published date from watch_html by parsing `<meta itemprop="datePublished" content="2016-11-14">` tag.
