### PR TITLE
Update playlist.py

### DIFF
--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -165,11 +165,14 @@ class Playlist(object):
                     progressive=True, subtype='mp4',
                 ).order_by('resolution').desc().first()
 
-                logger.debug('download path: %s', download_path)
-                if prefix_number:
-                    prefix = next(prefix_gen)
-                    logger.debug('file prefix is: %s', prefix)
-                    dl_stream.download(download_path, filename_prefix=prefix)
+                if dl_stream == None:
+                	break
                 else:
-                    dl_stream.download(download_path)
-                logger.debug('download complete')
+                    logger.debug('download path: %s', download_path)
+                    if prefix_number:
+                        prefix = next(prefix_gen)
+                        logger.debug('file prefix is: %s', prefix)
+                        dl_stream.download(download_path, filename_prefix=prefix)
+                    else:
+                        dl_stream.download(download_path)
+                        logger.debug('download complete')


### PR DESCRIPTION
Hey,

I noticed when using the playlist function on a big german playlist, that it would stop on URLS with % signs in it.
But instead of stopping the whole program, I would prefer that it just continues to download the rest of the files.
Somehow this fix also allowed me to download the files even with % signs in them.
Before it would break with saying NoneType object has no download function.

