### PR TITLE
Add multithread option to prefetch

### DIFF
--- a/pytube/__main__.py
+++ b/pytube/__main__.py
@@ -150,7 +150,7 @@ class YouTube(object):
     def do_get(self, url, result, index):
         result[index] = request.get(url=url)
 
-    def prefetch(self, multithread = False):
+    def prefetch(self, multithread=False):
         """Eagerly download all necessary data.
 
         Eagerly executes all necessary network requests so all other
@@ -183,14 +183,16 @@ class YouTube(object):
         )
         if multithread:
             threads, results = [None] * 2, [None] * 2
-            threads[0] = Thread(target=self.do_get, args=(self.vid_info_url, results, 0))
+            args = (self.vid_info_url, results, 0)
+            threads[0] = Thread(target=self.do_get, args=args)
             threads[0].start()
         else:
             self.vid_info = request.get(self.vid_info_url)
         if not self.age_restricted:
             self.js_url = extract.js_url(self.watch_html, self.age_restricted)
             if multithread:
-                threads[1] = Thread(target=self.do_get, args=(self.js_url, results, 1))
+                args = (self.js_url, results, 1)
+                threads[1] = Thread(target=self.do_get, args=args)
                 threads[1].start()
                 threads[0].join()
                 threads[1].join()
@@ -200,7 +202,6 @@ class YouTube(object):
             threads[0].join()
         if multithread:
             self.vid_info, self.js = results
-
 
     def initialize_stream_objects(self, fmt):
         """Convert manifest data to instances of :class:`Stream <Stream>`.


### PR DESCRIPTION
Help with issue #208, speed up the prefetch function with a couple of uses of multithreading. Could perhaps be tidied up. Seems like about 25% faster. Use by deferring the prefetch and init, then call prefetch with a True, and then init. eg

```
>>> if True:
...     start = time()
...     yt=YouTube('https://www.youtube.com/watch?v=dFjIPacvz2c', defer_prefetch_init=False)
...     print time() - start
... 
3.20481085777
>>> if True:
...     start = time()
...     yt=YouTube('https://www.youtube.com/watch?v=dFjIPacvz2c', defer_prefetch_init=True)
...     yt.prefetch(multithread=True)
...     yt.init()
...     print time() - start
... 
2.33701705933
```