### PR TITLE
possible fix #347: added check for ciphered signature existence in stream

### DIFF
--- a/pytube/mixins.py
+++ b/pytube/mixins.py
@@ -46,7 +46,12 @@ def apply_signature(config_args, fmt, js):
             continue
 
         if js is not None:
-            signature = cipher.get_signature(js, stream['s'])
+            if 's' not in stream:
+                logger.error('Ciphered signature not found in stream!')
+                # Can be changed to another exception typem or simply ignored.
+                raise TypeError('Ciphered signature is None')
+            ciphered_signature = stream['s']
+            signature = cipher.get_signature(js, ciphered_signature)
         else:
             # signature not present in url (line 33), need js to descramble
             # TypeError caught in __main__


### PR DESCRIPTION
There was no check for `'s'` in `stream`, so that was able to cause unexpected KeyError exceptions. I've added check but didn't know ignore it or not, or use some type of exception in this case. I've added TypeError one, but I think it should be processed anyway better.