### PR TITLE
Remove unavailable video check

### DIFF
--- a/pytube/__main__.py
+++ b/pytube/__main__.py
@@ -21,7 +21,6 @@ from pytube import Stream
 from pytube import StreamQuery
 from pytube.compat import install_proxy
 from pytube.compat import parse_qsl
-from pytube.exceptions import VideoUnavailable
 from pytube.helpers import apply_mixin
 
 logger = logging.getLogger(__name__)
@@ -158,8 +157,6 @@ class YouTube(object):
 
         """
         self.watch_html = request.get(url=self.watch_url)
-        if '<img class="icon meh" src="/yts/img' not in self.watch_html:
-            raise VideoUnavailable('This video is unavailable.')
         self.embed_html = request.get(url=self.embed_url)
         self.age_restricted = extract.is_age_restricted(self.watch_html)
         self.vid_info_url = extract.video_info_url(

--- a/pytube/exceptions.py
+++ b/pytube/exceptions.py
@@ -38,7 +38,3 @@ class RegexMatchError(ExtractError):
 
 class LiveStreamError(ExtractError):
     """Video is a live stream."""
-
-
-class VideoUnavailable(PytubeError):
-    """Video is unavailable."""


### PR DESCRIPTION
- https://github.com/nficano/pytube/pull/258/ breaks the download age restricted videos code which this PR reverts
- https://github.com/nficano/pytube/pull/258/ was for https://github.com/nficano/pytube/issues/250 - not sure how feasible it is to implement a solution, e.g. `youtube-dl  https://www.youtube.com/watch?v=IW1mdGDSGYQ` outputs `ERROR: This live stream recording is not available.` @billd100 
- tested on https://www.youtube.com/watch?v=irauhITDrsE