### PR TITLE
Temporary fix for  regex pattern error

### DIFF
--- a/pytube/extract.py
+++ b/pytube/extract.py
@@ -116,17 +116,17 @@ def video_info_url(
     else:
         # I'm not entirely sure what ``t`` represents. Looks to represent a
         # boolean.
-        t = regex_search(
-            r'\W[\'"]?t[\'"]?: ?[\'"](.+?)[\'"]', watch_html,
-            group=0,
-        )
+        # t = regex_search(
+        #     r'\W[\'"]?t[\'"]?: ?[\'"](.+?)[\'"]', watch_html,
+        #     group=0,
+        # )
         params = OrderedDict([
             ('video_id', video_id),
             ('el', '$el'),
             ('ps', 'default'),
             ('eurl', quote(watch_url)),
             ('hl', 'en_US'),
-            ('t', quote(t)),
+            #('t', quote(t)),
         ])
     return 'https://youtube.com/get_video_info?' + urlencode(params)
 


### PR DESCRIPTION
Temporary fix for  regex pattern (\W[\'"]?t[\'"]?: ?[\'"](.+?)[\'"]) had zero matches