### PR TITLE
Change in URL "signature" parameter is now "sig" as of 12Jun2019.

### DIFF
--- a/pytube/mixins.py
+++ b/pytube/mixins.py
@@ -45,6 +45,13 @@ def apply_signature(config_args, fmt, js):
             logger.debug('signature found, skip decipher')
             continue
 
+        if 'sig=' in url:
+            # For certain videos, YouTube will just provide them pre-signed, in
+            # which case there's no real magic to download them and we can skip
+            # the whole signature descrambling entirely.
+            logger.debug('signature found, skip decipher')
+            continue
+
         if js is not None:
             signature = cipher.get_signature(js, stream['s'])
         else:


### PR DESCRIPTION
Currently I am getting an error (e.g. for the video: https://www.youtube.com/watch?v=eWMlClLpTBE)

***CONSOLE OUTPUT***
$ python main.py https://www.youtube.com/watch?v=eWMlClLpTBE
Traceback (most recent call last):
  File "main.py", line 4, in <module>
    yt = YouTube(sys.argv[1])
  File "c:\Users\vasilyev\AGVDocs\Dev\Python\6.2 pytube_forked\pytube\pytube\__main__.py", line 88, in __init__

    self.prefetch_init()
  File "c:\Users\vasilyev\AGVDocs\Dev\Python\6.2 pytube_forked\pytube\pytube\__main__.py", line 97, in prefetch_init
    self.init()
  File "c:\Users\vasilyev\AGVDocs\Dev\Python\6.2 pytube_forked\pytube\pytube\__main__.py", line 133, in init
    mixins.apply_signature(self.player_config_args, fmt, self.js)
  File "c:\Users\vasilyev\AGVDocs\Dev\Python\6.2 pytube_forked\pytube\pytube\mixins.py", line 49, in apply_signature
    signature = cipher.get_signature(js, stream['s'])
KeyError: 's'

*** END OF CONSOLE OUTPUT ***

*** FILE main.py ****
import sys
from pytube import YouTube

yt = YouTube(sys.argv[1])
strms = yt.streams.all()

goodStrms = []
for strm in strms:
    if (strm.audio_codec is not None and
        strm.video_codec is not None):
        goodStrms.append(strm)

i=1
strmDict = {}
for strm in goodStrms:
        print("{} - {}".format(i, strm))
        strmDict[i] = strm
        i+=1

strmToDownID = input("Which stream do you need?")

strmToDownID = int(strmToDownID)
print("Stream {} {} is selected".format(strmToDownID, strmDict[strmToDownID]))
print("downloading:")

strmDict[strmToDownID].download()
print("Download complete")

*** END OF FILE main.py ****


I have made a little patch (which may not be very well thought through) which solves the problem adding  "sig" and "signature" parameters of URL to be treated in the same way (at least in mixins.py). It solves the problem for the URL above.