### PR TITLE
Fix not generating the signature when `lsig` is present

### DIFF
--- a/pytube/mixins.py
+++ b/pytube/mixins.py
@@ -38,7 +38,8 @@ def apply_signature(config_args, fmt, js):
         elif live_stream:
             raise LiveStreamError('Video is currently being streamed live')
 
-        if any([x in url for x in ['signature=', 'sig=']]) and 'lsig=' not in url:
+        if any([x in url for x in ['signature=', 'sig=']]) and \
+                'lsig=' not in url:
             # For certain videos, YouTube will just provide them pre-signed, in
             # which case there's no real magic to download them and we can skip
             # the whole signature descrambling entirely.

--- a/pytube/mixins.py
+++ b/pytube/mixins.py
@@ -38,7 +38,7 @@ def apply_signature(config_args, fmt, js):
         elif live_stream:
             raise LiveStreamError('Video is currently being streamed live')
 
-        if any([x in url for x in ['signature=', 'sig=']]):
+        if any([x in url for x in ['signature=', 'sig=']]) and not 'lsig=' in url:
             # For certain videos, YouTube will just provide them pre-signed, in
             # which case there's no real magic to download them and we can skip
             # the whole signature descrambling entirely.

--- a/pytube/mixins.py
+++ b/pytube/mixins.py
@@ -38,7 +38,7 @@ def apply_signature(config_args, fmt, js):
         elif live_stream:
             raise LiveStreamError('Video is currently being streamed live')
 
-        if any([x in url for x in ['signature=', 'sig=']]) and not 'lsig=' in url:
+        if any([x in url for x in ['signature=', 'sig=']]) and 'lsig=' not in url:
             # For certain videos, YouTube will just provide them pre-signed, in
             # which case there's no real magic to download them and we can skip
             # the whole signature descrambling entirely.

--- a/pytube/mixins.py
+++ b/pytube/mixins.py
@@ -38,8 +38,7 @@ def apply_signature(config_args, fmt, js):
         elif live_stream:
             raise LiveStreamError('Video is currently being streamed live')
 
-        if any([x in url for x in ['signature=', 'sig=']]) and \
-                'lsig=' not in url:
+        if any([x in url for x in ['signature=', '&sig=', '?sig=']]):
             # For certain videos, YouTube will just provide them pre-signed, in
             # which case there's no real magic to download them and we can skip
             # the whole signature descrambling entirely.


### PR DESCRIPTION
This only fixes one part of the 403 error, #425 is required to fix regex not matching, and line 64 needs 'signature' replaced with 'sig' in some cases

Combining this with the other two fixes, I'm no longer getting any error 403