### PR TITLE
Change 'signature' -> 'sig' in generated URL

### DIFF
--- a/pytube/mixins.py
+++ b/pytube/mixins.py
@@ -61,7 +61,7 @@ def apply_signature(config_args, fmt, js):
                 }, indent=2,
             ),
         )
-        stream_manifest[i]['url'] = url + '&signature=' + signature
+        stream_manifest[i]['url'] = url + '&sig=' + signature
 
 
 def apply_descrambler(stream_data, key):


### PR DESCRIPTION
The third and final piece of the 403 error that I can find, submitted as a separate PR because I'm not sure that downloading still works in all cases with this change. Combine with #425 and #426 for the complete fix.