### PR TITLE
Fixed an error: lookup of video title failed

### DIFF
--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -173,7 +173,7 @@ class Stream(object):
         :returns:
             An os file system compatible filename.
         """
-        title = self.player_config_args['title']
+        title = self.player_config_args['player_response']['videoDetails']['title']
         filename = safe_filename(title)
         return '{filename}.{s.subtype}'.format(filename=filename, s=self)
 


### PR DESCRIPTION
When executing this on my system, this error occured every time I tried to download a video:

C:\ProgramData\Anaconda3\lib\site-packages\pytube\streams.py in default_filename(self)
    174             An os file system compatible filename.
    175         """
--> 176         title = self.player_config_args['title']
    177         filename = safe_filename(title)
    178         return '{filename}.{s.subtype}'.format(filename=filename, s=self)
KeyError: 'title'

I inspected what the object self.player_config_args looked like, and this fixed the problem.
It appears that the self.player_config_args object has changed recently, creating an invalid key in the dictionary.