### PR TITLE
Added functionality to register_on_complete_callback

### DIFF
--- a/pytube/__main__.py
+++ b/pytube/__main__.py
@@ -77,8 +77,8 @@ class YouTube(object):
         # (Borg pattern).
         self.stream_monostate = {
             # user defined callback functions.
-            'on_progress': on_progress_callback,
-            'on_complete': on_complete_callback,
+            'on_progress': [on_progress_callback, None, None],
+            'on_complete': [on_complete_callback, None, None],
         }
 
         if proxies:
@@ -299,25 +299,27 @@ class YouTube(object):
             .get('viewCount')
         )
 
-    def register_on_progress_callback(self, func):
+    def register_on_progress_callback(self, func, *args, **kwargs):
         """Register a download progress callback function post initialization.
 
         :param callable func:
             A callback function that takes ``stream``, ``chunk``,
             ``file_handle``, ``bytes_remaining`` as parameters.
+            Additionally, passes user-defined args and kwargs
 
         :rtype: None
 
         """
-        self.stream_monostate['on_progress'] = func
+        self.stream_monostate['on_progress'] = [func, args, kwargs]
 
-    def register_on_complete_callback(self, func):
+    def register_on_complete_callback(self, func, *args, **kwargs):
         """Register a download complete callback function post initialization.
 
         :param callable func:
             A callback function that takes ``stream`` and  ``file_handle``.
+            Additionally, passes user-defined args and kwargs
 
         :rtype: None
 
         """
-        self.stream_monostate['on_complete'] = func
+        self.stream_monostate['on_complete'] = [func, args, kwargs]

--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -279,10 +279,10 @@ class Stream(object):
                 }, indent=2,
             ),
         )
-        on_progress = self._monostate['on_progress']
+        on_progress, args, kwargs = self._monostate['on_progress']
         if on_progress:
             logger.debug('calling on_progress callback %s', on_progress)
-            on_progress(self, chunk, file_handler, bytes_remaining)
+            on_progress(self, chunk, file_handler, bytes_remaining, *args, **kwargs)
 
     def on_complete(self, file_handle):
         """On download complete handler function.
@@ -296,10 +296,10 @@ class Stream(object):
 
         """
         logger.debug('download finished')
-        on_complete = self._monostate['on_complete']
+        on_complete, args, kwargs = self._monostate['on_complete']
         if on_complete:
             logger.debug('calling on_complete callback %s', on_complete)
-            on_complete(self, file_handle)
+            on_complete(self, file_handle, *args, **kwargs)
 
     def __repr__(self):
         """Printable object representation.


### PR DESCRIPTION
Enables users to pass args, kwargs to the callback for on_complete and on_progress.

Maybe there is a smarter way to do this, but I am downloading a massive number of videos from Youtube (>400k) with a large number of parallel workers. I needed a way to run post-processing script on each video once it was finished downloading. I found the callback for on_complete, but it lacked the ability to pass additional information from the current worker. 

The best way I figured was to fix the callback such that it would take arbitrary user-defined args and kwargs. I figured that others might want this functionality as well; however, please feel free to disregard this if it is a poor design.

Thanks!

Here's a toy example:
```python
import sys
import pytube

def download_in_progress(stream, chunk, file_handler, bytes_remaining, custom_string):
    sys.stdout.write(f'\r{custom_string} {bytes_remaining}')
    sys.stdout.flush()

def download_finished(stream, file_handle, custom_func):
    print("\nDownload complete!")
    print("Running post processing function...")
    custom_func()

def main(youtube_ID, post_proc_func):
    youtube_path = f'https://www.youtube.com/watch?v={youtube_ID}'
    video = pytube.YouTube(youtube_path)
    video.register_on_complete_callback(download_finished, custom_func=post_proc_func)
    video.register_on_progress_callback(download_in_progress, custom_string='Remaining: ')

    stream = video.streams.filter(progressive=True).order_by('resolution').desc().first()

    stream.download(output_path='downloads', filename='test')
```