### PR TITLE
Fixed the bug # 450

### DIFF
--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -176,7 +176,7 @@ class Stream(object):
         player_config_args = self.player_config_args or {}
 
         if 'title' in player_config_args:
-            return player_config_args['player_config_args']
+            return player_config_args['title']
 
         details = self.player_config_args.get(
             'player_response', {}).get('videoDetails', {})

--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -166,6 +166,27 @@ class Stream(object):
         return self._filesize
 
     @property
+    def title(self):
+        """Get title of video
+
+        :rtype: str
+        :returns:
+            Youtube video title
+        """
+        player_config_args = self.player_config_args or {}
+
+        if 'title' in player_config_args:
+            return player_config_args['player_config_args']
+
+        details = self.player_config_args.get(
+            'player_response', {}).get('videoDetails', {})
+
+        if 'title' in details:
+            return details['title']
+
+        return 'Unknown YouTube Video Title'
+
+    @property
     def default_filename(self):
         """Generate filename based on the video title.
 
@@ -173,8 +194,8 @@ class Stream(object):
         :returns:
             An os file system compatible filename.
         """
-        title = self.player_config_args['title']
-        filename = safe_filename(title)
+
+        filename = safe_filename(self.title)
         return '{filename}.{s.subtype}'.format(filename=filename, s=self)
 
     def download(self, output_path=None, filename=None, filename_prefix=None):

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -26,7 +26,7 @@ def test_title(cipher_signature):
 
     expected = 'PSY - GANGNAM STYLE(강남스타일)'
     stream.player_config_args = {
-        'player_response': {'videoDetails': expected}}
+        'player_response': {'videoDetails': {'title': expected}}}
     assert stream.title == expected
 
     expected = 'Unknown YouTube Video Title'

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -19,6 +19,12 @@ def test_default_filename(cipher_signature):
     assert stream.default_filename == expected
 
 
+def test_title(cipher_signature):
+    expected = 'PSY - GANGNAM STYLE(강남스타일) MV'
+    stream = cipher_signature.streams.first()
+    assert stream.title == expected
+
+
 def test_download(cipher_signature, mocker):
     mocker.patch.object(request, 'get')
     request.get.side_effect = [

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -20,7 +20,7 @@ def test_default_filename(cipher_signature):
 
 
 def test_title(cipher_signature):
-    expected = 'PSY - GANGNAM STYLE(강남스타일) MV'
+    expected = 'PSY - GANGNAM STYLE(강남스타일) M/V'
     stream = cipher_signature.streams.first()
     assert stream.title == expected
 

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -24,6 +24,15 @@ def test_title(cipher_signature):
     stream = cipher_signature.streams.first()
     assert stream.title == expected
 
+    expected = 'PSY - GANGNAM STYLE(강남스타일)'
+    stream.player_config_args = {
+        'player_response': {'videoDetails': expected}}
+    assert stream.title == expected
+
+    expected = 'Unknown YouTube Video Title'
+    stream.player_config_args = {}
+    assert stream.title == expected
+
 
 def test_download(cipher_signature, mocker):
     mocker.patch.object(request, 'get')


### PR DESCRIPTION
When I tried to use the "default_filename" I got the exception.
A few users had the same problem:
https://github.com/nficano/pytube/issues/450

`>>> from pytube import YouTube`
`>>> YouTube('http://youtube.com/watch?v=9bZkp7q19f0').streams.first().default_filename`
`Traceback (most recent call last):`
`  File "<input>", line 1, in <module>`
`  File ".../lib/python3.7/site-packages/pytube/streams.py", line 176, in default_filename
    title = self.player_config_args['title']`
`KeyError: 'title'`


