### PR TITLE
Fix #467 KeyError: 'url_encoded_fmt_stream_map'

### DIFF
--- a/pytube/__main__.py
+++ b/pytube/__main__.py
@@ -138,6 +138,9 @@ class YouTube(object):
 
         # unscramble the progressive and adaptive stream manifests.
         for fmt in stream_maps:
+            if fmt not in self.player_config_args:
+                continue
+
             if not self.age_restricted and fmt in self.vid_info:
                 mixins.apply_descrambler(self.vid_info, fmt)
             mixins.apply_descrambler(self.player_config_args, fmt)


### PR DESCRIPTION
[fix] If there is no key in self.player_config_args, skip the processing that was planned to be done with that key and execute the process for the next key