### PR TITLE
Fixed cipher.py: Invalid regex and in query.py: order_by() None attribute case

### DIFF
--- a/pytube/cipher.py
+++ b/pytube/cipher.py
@@ -42,7 +42,7 @@ def get_initial_function_name(js):
         r'(?P<sig>[a-zA-Z0-9$]+)\s*=\s*function\(\s*a\s*\)\s*{\s*a\s*=\s*a\.split\(\s*""\s*\)',  # noqa: E501
         r'(["\'])signature\1\s*,\s*(?P<sig>[a-zA-Z0-9$]+)\(',
         r'\.sig\|\|(?P<sig>[a-zA-Z0-9$]+)\(',
-        r'yt\.akamaized\.net/\)\s*\|\|\s*.*?\s*[cs]\s*&&\s*[adf]\.set\([^,]+\s*,\s*(?:encodeURIComponent\s*\()?\s*(?P<si$',  # noqa: E501
+        r'yt\.akamaized\.net/\)\s*\|\|\s*.*?\s*[cs]\s*&&\s*[adf]\.set\([^,]+\s*,\s*(?:encodeURIComponent\s*\()?\s*(?P<sig>[a-zA-Z0-9$]+)\(',  # noqa: E501
         r'\b[cs]\s*&&\s*[adf]\.set\([^,]+\s*,\s*(?P<sig>[a-zA-Z0-9$]+)\(',  # noqa: E501
         r'\b[a-zA-Z0-9]+\s*&&\s*[a-zA-Z0-9]+\.set\([^,]+\s*,\s*(?P<sig>[a-zA-Z0-9$]+)\(',  # noqa: E501
         r'\bc\s*&&\s*a\.set\([^,]+\s*,\s*\([^)]*\)\s*\(\s*(?P<sig>[a-zA-Z0-9$]+)\(',  # noqa: E501

--- a/pytube/query.py
+++ b/pytube/query.py
@@ -179,10 +179,9 @@ class StreamQuery:
             def key(s):
                 return getattr(s, attribute_name)
 
-        fmt_streams = sorted(
-            fmt_streams,
-            key=key,
-        )
+        # We can sort in place instead of calling sorted()
+        fmt_streams.sort(key=key)
+
         return StreamQuery(fmt_streams)
 
     def desc(self):

--- a/pytube/query.py
+++ b/pytube/query.py
@@ -166,7 +166,7 @@ class StreamQuery:
         integer_attr_repr = {}
         for stream in self.fmt_streams:
             attr = getattr(stream, attribute_name)
-            if attr is not None:
+            if attr:
                 fmt_streams.append(stream)
                 num = ''.join(x for x in attr if x.isdigit())
                 integer_attr_repr[attr] = int(''.join(num)) if num else None

--- a/pytube/query.py
+++ b/pytube/query.py
@@ -162,13 +162,14 @@ class StreamQuery:
         :param str attribute_name:
             The name of the attribute to sort by.
         """
+        fmt_streams = []
         integer_attr_repr = {}
         for stream in self.fmt_streams:
             attr = getattr(stream, attribute_name)
-            if attr is None:
-                break
-            num = ''.join(x for x in attr if x.isdigit())
-            integer_attr_repr[attr] = int(''.join(num)) if num else None
+            if attr is not None:
+                fmt_streams.append(stream)
+                num = ''.join(x for x in attr if x.isdigit())
+                integer_attr_repr[attr] = int(''.join(num)) if num else None
 
         # if every attribute has an integer representation
         if integer_attr_repr and all(integer_attr_repr.values()):
@@ -179,7 +180,7 @@ class StreamQuery:
                 return getattr(s, attribute_name)
 
         fmt_streams = sorted(
-            self.fmt_streams,
+            fmt_streams,
             key=key,
         )
         return StreamQuery(fmt_streams)


### PR DESCRIPTION
The RE in line 45 was truncated and malformed and does not compile.

```
>>> re.compile( r'yt\.akamaized\.net/\)\s*\|\|\s*.*?\s*[cs]\s*&&\s*[adf]\.set\([^,]+\s*,\s*(?:encodeURIComponent\s*\()?\s*(?P<si$')
Traceback (most recent call last):
// traceback details removed 
re.error: missing >, unterminated name at position 108
```