### PR TITLE
fix KeyError for 'url'

### DIFF
--- a/pytube/mixins.py
+++ b/pytube/mixins.py
@@ -91,10 +91,36 @@ def apply_descrambler(stream_data, key):
     {'foo': [{'bar': '1', 'var': 'test'}, {'em': '5', 't': 'url encoded'}]}
 
     """
-    stream_data[key] = [
-        {k: unquote(v) for k, v in parse_qsl(i)}
-        for i in stream_data[key].split(',')
-    ]
+    if key == 'url_encoded_fmt_stream_map' and not stream_data.get('url_encoded_fmt_stream_map'):
+        formats = json.loads(stream_data['player_response'])[
+            'streamingData']['formats']
+        formats.extend(json.loads(stream_data['player_response'])[
+                       'streamingData']['adaptiveFormats'])
+        try:
+            stream_data[key] = [{u'url': format_item[u'url'],
+                                 u'type': format_item[u'mimeType'],
+                                 u'quality': format_item[u'quality'],
+                                 u'itag': format_item[u'itag']} for format_item in formats]
+        except KeyError:
+            cipher_url = [parse_qsl(formats[i]['cipher'])
+                          for i, data in enumerate(formats)]
+            stream_data[key] = []
+            for i, format_item in enumerate(formats):
+                stream_data[key].append({u'type': format_item[u'mimeType'],
+                                         u'quality': format_item[u'quality'],
+                                         u'itag': format_item[u'itag']})
+                for c in cipher_url[i]:
+                    if c[0] in "url":
+                        stream_data[key][i].update({'url': c[1]})
+                    elif c[0] in "s":
+                        stream_data[key][i].update({'s': c[1]})
+                    elif c[0] in "sp":
+                        stream_data[key][i].update({"sp": c[1]})
+    else:
+        stream_data[key] = [
+            {k: unquote(v) for k, v in parse_qsl(i)}
+            for i in stream_data[key].split(',')
+        ]
     logger.debug(
         'applying descrambler\n%s',
         pprint.pformat(stream_data[key], indent=2),


### PR DESCRIPTION
Sometimes we encounted KeyError for 'url' Because of under the lines.
type of cipher_url is tuple, not dict. so it could not add url including
in stream_data['url_encoded_fmt_stream_map'].
so i changed way to add stream_data['url_encoded_fmt_stream_map'].