### PR TITLE
Fix: Add support for streaming data to mixins.apply_descrambler

### DIFF
--- a/pytube/mixins.py
+++ b/pytube/mixins.py
@@ -91,15 +91,26 @@ def apply_descrambler(stream_data, key):
     {'foo': [{'bar': '1', 'var': 'test'}, {'em': '5', 't': 'url encoded'}]}
 
     """
+    import urllib.parse
     if key == 'url_encoded_fmt_stream_map' and not stream_data.get('url_encoded_fmt_stream_map'):
-        formats = json.loads(stream_data['player_response'])[
-            'streamingData']['formats']
-        formats.extend(json.loads(stream_data['player_response'])[
-                       'streamingData']['adaptiveFormats'])
-        stream_data[key] = [{u'url': format_item[u'url'],
-                             u'type': format_item[u'mimeType'],
-                             u'quality': format_item[u'quality'],
-                             u'itag': format_item[u'itag']} for format_item in formats]
+
+        try:
+            formats = json.loads(stream_data['player_response'])['streamingData']['formats']
+            formats.extend(json.loads(stream_data['player_response'])['streamingData']['adaptiveFormats'])
+        except:
+            formats = json.loads(stream_data['player_response'])['streamingData']['adaptiveFormats']
+        try:
+            stream_data[key] = [{u'url': format_item[u'url'],
+                                 u'type': format_item[u'mimeType'],
+                                 u'quality': format_item[u'quality'],
+                                 u'itag': format_item[u'itag']} for format_item in formats]
+        except:
+            stream_data[key] = [{u'url': urllib.parse.unquote([url_item for url_item in format_item[u'cipher'].split("&") if "url=" in url_item][0].split("=")[1]),
+                                  u'sp': urllib.parse.unquote([url_item for url_item in format_item[u'cipher'].split("&") if "sp=" in url_item][0].split("=")[1]),
+                                  u's': urllib.parse.unquote([url_item for url_item in format_item[u'cipher'].split("&") if "s=" in url_item][0].split("=")[1]),
+                                  u'type': format_item[u'mimeType'],
+                                  u'quality': format_item[u'quality'],
+                                  u'itag': format_item[u'itag']} for format_item in formats]
     else:
         stream_data[key] = [
             {k: unquote(v) for k, v in parse_qsl(i)}

--- a/pytube/mixins.py
+++ b/pytube/mixins.py
@@ -91,10 +91,20 @@ def apply_descrambler(stream_data, key):
     {'foo': [{'bar': '1', 'var': 'test'}, {'em': '5', 't': 'url encoded'}]}
 
     """
-    stream_data[key] = [
-        {k: unquote(v) for k, v in parse_qsl(i)}
-        for i in stream_data[key].split(',')
-    ]
+    if key == 'url_encoded_fmt_stream_map' and not stream_data.get('url_encoded_fmt_stream_map'):
+        formats = json.loads(stream_data['player_response'])[
+            'streamingData']['formats']
+        formats.extend(json.loads(stream_data['player_response'])[
+                       'streamingData']['adaptiveFormats'])
+        stream_data[key] = [{u'url': format_item[u'url'],
+                             u'type': format_item[u'mimeType'],
+                             u'quality': format_item[u'quality'],
+                             u'itag': format_item[u'itag']} for format_item in formats]
+    else:
+        stream_data[key] = [
+            {k: unquote(v) for k, v in parse_qsl(i)}
+            for i in stream_data[key].split(',')
+        ]
     logger.debug(
         'applying descrambler\n%s',
         pprint.pformat(stream_data[key], indent=2),


### PR DESCRIPTION
This pull request merges a couple of fixes to the mixins.apply_descrambler. Specifically those from @giacaglia [here](https://github.com/nficano/pytube/issues/467#issuecomment-568609340) and @FidoDidoVN [here](https://github.com/nficano/pytube/issues/467#issuecomment-568311609)

It also adds a try - except case for videos that were failing because they didn't have a 'formats' in the stream_data json