### PR TITLE
adaptive format fix

### DIFF
--- a/pytube/extract.py
+++ b/pytube/extract.py
@@ -278,7 +278,11 @@ def apply_descrambler(stream_data: Dict, key: str) -> None:
     if key == "url_encoded_fmt_stream_map" and not stream_data.get(
         "url_encoded_fmt_stream_map"
     ):
-        formats = json.loads(stream_data["player_response"])["streamingData"]["formats"]
+        streamingData = json.loads(stream_data["player_response"])["streamingData"]
+        if 'formats' in streamingData.keys():
+            formats = json.loads(stream_data["player_response"])["streamingData"]["formats"]
+        elif 'adaptiveFormats' in streamingData.keys():
+            formats = json.loads(stream_data["player_response"])["streamingData"]["adaptiveFormats"]
         formats.extend(
             json.loads(stream_data["player_response"])["streamingData"][
                 "adaptiveFormats"


### PR DESCRIPTION
Sometimes the `json.loads(yt.player_config_args["player_response"])['streamingData']` has no `formats` key, but has a key called `adaptiveFormats` containing exactly the same information. This PR also works for these examples.

For instance in the case of `https://www.youtube.com/watch?v=mRe-514tGMg`