### PR TITLE
Add logic to detect occurences of signatureCipher in stream_data formats.

### DIFF
--- a/pytube/extract.py
+++ b/pytube/extract.py
@@ -298,7 +298,12 @@ def apply_descrambler(stream_data: Dict, key: str) -> None:
             ]
         except KeyError:
             cipher_url = [
-                parse_qs(formats[i]["cipher"]) for i, data in enumerate(formats)
+                parse_qs(
+                    formats[i][
+                        "cipher" if "cipher" in data.keys() else "signatureCipher"
+                    ]
+                )
+                for i, data in enumerate(formats)
             ]
             stream_data[key] = [
                 {


### PR DESCRIPTION
Occasionally, YouTube does not include the ```cipher``` key in the ```stream_data``` dict. In these cases, it uses ```signatureCipher``` instead. I've added some logic to detect this and swap the former for the latter.

In my experience, this only happens when the videos are part of a playlist, and even then only sometimes.