### PR TITLE
Provide backward compability to Python 3.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ test/**/*.xml
 .idea/tasks.xml
 .idea/modules.xml
 .idea/*.iml
+venv/
+.python-version

--- a/pytube/__main__.py
+++ b/pytube/__main__.py
@@ -34,10 +34,10 @@ class YouTube:
     def __init__(
         self,
         url: str,
-        defer_prefetch_init: bool = False,
-        on_progress_callback: Optional[OnProgress] = None,
-        on_complete_callback: Optional[OnComplete] = None,
-        proxies: Dict[str, str] = None,
+        defer_prefetch_init = False,
+        on_progress_callback = None,
+        on_complete_callback = None,
+        proxies = None,
     ):
         """Construct a :class:`YouTube <YouTube>`.
 

--- a/pytube/__main__.py
+++ b/pytube/__main__.py
@@ -53,25 +53,25 @@ class YouTube:
             complete events.
 
         """
-        self.js: Optional[str] = None  # js fetched by js_url
-        self.js_url: Optional[str] = None  # the url to the js, parsed from watch html
+        self.js = None  # js fetched by js_url
+        self.js_url = None  # the url to the js, parsed from watch html
 
         # note: vid_info may eventually be removed. It sounds like it once had
         # additional formats, but that doesn't appear to still be the case.
 
         # the url to vid info, parsed from watch html
-        self.vid_info_url: Optional[str] = None
-        self.vid_info_raw: Optional[str] = None  # content fetched by vid_info_url
-        self.vid_info: Optional[Dict] = None  # parsed content of vid_info_raw
+        self.vid_info_url = None
+        self.vid_info_raw = None  # content fetched by vid_info_url
+        self.vid_info = None  # parsed content of vid_info_raw
 
-        self.watch_html: Optional[str] = None  # the html of /watch?v=<video_id>
-        self.embed_html: Optional[str] = None
-        self.player_config_args: Dict = {}  # inline js in the html containing
-        self.player_response: Dict = {}
+        self.watch_html = None  # the html of /watch?v=<video_id>
+        self.embed_html = None
+        self.player_config_args = {}  # inline js in the html containing
+        self.player_response = {}
         # streams
-        self.age_restricted: Optional[bool] = None
+        self.age_restricted = None
 
-        self.fmt_streams: List[Stream] = []
+        self.fmt_streams = []
 
         # video_id part of /watch?v=<video_id>
         self.video_id = extract.video_id(url)

--- a/pytube/__main__.py
+++ b/pytube/__main__.py
@@ -76,8 +76,8 @@ class YouTube:
         # video_id part of /watch?v=<video_id>
         self.video_id = extract.video_id(url)
 
-        self.watch_url = f"https://youtube.com/watch?v={self.video_id}"
-        self.embed_url = f"https://www.youtube.com/embed/{self.video_id}"
+        self.watch_url = "https://youtube.com/watch?v={}".format(self.video_id)
+        self.embed_url = "https://www.youtube.com/embed/{}".format(self.video_id)
 
         # Shared between all instances of `Stream` (Borg pattern).
         self.stream_monostate = Monostate(
@@ -251,7 +251,7 @@ class YouTube:
             thumbnail_details = thumbnail_details[-1]  # last item has max size
             return thumbnail_details["url"]
 
-        return f"https://img.youtube.com/vi/{self.video_id}/maxresdefault.jpg"
+        return "https://img.youtube.com/vi/{}/maxresdefault.jpg".format(self.video_id)
 
     @property
     def title(self) -> str:

--- a/pytube/captions.py
+++ b/pytube/captions.py
@@ -47,7 +47,7 @@ class Caption:
         """
         fraction, whole = math.modf(d)
         time_fmt = time.strftime("%H:%M:%S,", time.gmtime(whole))
-        ms = f"{fraction:.3f}".replace("0.", "")
+        ms = "{:.3f}".format(fraction).replace("0.", "")
         return time_fmt + ms
 
     def xml_caption_to_srt(self, xml_captions: str) -> str:
@@ -110,11 +110,11 @@ class Caption:
             filename = title
 
         if filename_prefix:
-            filename = f"{safe_filename(filename_prefix)}{filename}"
+            filename = "{}{}".format(safe_filename(filename_prefix), filename)
 
         filename = safe_filename(filename)
 
-        filename += f" ({self.code})"
+        filename += " ({})".format(self.code)
 
         if srt:
             filename += ".srt"

--- a/pytube/captions.py
+++ b/pytube/captions.py
@@ -77,9 +77,9 @@ class Caption:
     def download(
         self,
         title: str,
-        srt: bool = True,
-        output_path: Optional[str] = None,
-        filename_prefix: Optional[str] = None,
+        srt = True,
+        output_path = None,
+        filename_prefix = None,
     ) -> str:
         """Write the media stream to disk.
 

--- a/pytube/cipher.py
+++ b/pytube/cipher.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 class Cipher:
     def __init__(self, js: str):
-        self.transform_plan: List[str] = get_transform_plan(js)
+        self.transform_plan = get_transform_plan(js)
         var, _ = self.transform_plan[0].split(".")
         self.transform_map = get_transform_map(js, var)
         self.js_func_regex = re.compile(r"\w+\.(\w+)\(\w,(\d+)\)")

--- a/pytube/cli.py
+++ b/pytube/cli.py
@@ -71,7 +71,7 @@ def _perform_args_on_youtube(youtube: YouTube, args: argparse.Namespace) -> None
 
 
 def _parse_args(
-    parser: argparse.ArgumentParser, args: Optional[List] = None
+    parser: argparse.ArgumentParser, args = None
 ) -> argparse.Namespace:
     parser.add_argument("url", help="The YouTube /watch or /playlist url", nargs="?")
     parser.add_argument(
@@ -176,7 +176,7 @@ def build_playback_report(youtube: YouTube) -> None:
 
 
 def display_progress_bar(
-    bytes_received: int, filesize: int, ch: str = "█", scale: float = 0.55
+    bytes_received: int, filesize: int, ch: str = "█", scale = 0.55
 ) -> None:
     """Display a simple, pretty progress bar.
 
@@ -218,7 +218,7 @@ def on_progress(
 
 
 def _download(
-    stream: Stream, target: Optional[str] = None, filename: Optional[str] = None
+    stream: Stream, target: Optional[str] = None, filename = None
 ) -> None:
     filesize_megabytes = stream.filesize // 1048576
     print("{} | {} MB".format(filename or stream.default_filename, filesize_megabytes))
@@ -254,7 +254,7 @@ def _unique_name(base: str, subtype: str, media_type: str, target: str) -> str:
 
 
 def ffmpeg_process(
-    youtube: YouTube, resolution: str, target: Optional[str] = None
+    youtube: YouTube, resolution: str, target = None
 ) -> None:
     """
     Decides the correct video stream to download, then calls _ffmpeg_downloader.
@@ -370,7 +370,7 @@ def download_by_itag(youtube: YouTube, itag: int, target: Optional[str] = None) 
 
 
 def download_by_resolution(
-    youtube: YouTube, resolution: str, target: Optional[str] = None
+    youtube: YouTube, resolution: str, target = None
 ) -> None:
     """Start downloading a YouTube video.
 
@@ -413,7 +413,7 @@ def _print_available_captions(captions: CaptionQuery) -> None:
 
 
 def download_caption(
-    youtube: YouTube, lang_code: Optional[str], target: Optional[str] = None
+    youtube: YouTube, lang_code: Optional[str], target = None
 ) -> None:
     """Download a caption for the YouTube video.
 
@@ -440,7 +440,7 @@ def download_caption(
 
 
 def download_audio(
-    youtube: YouTube, filetype: str, target: Optional[str] = None
+    youtube: YouTube, filetype: str, target = None
 ) -> None:
     """
     Given a filetype, downloads the highest quality available audio stream for a

--- a/pytube/cli.py
+++ b/pytube/cli.py
@@ -41,7 +41,7 @@ def main():
             try:
                 _perform_args_on_youtube(youtube_video, args)
             except PytubeError as e:
-                print(f"There was an error with video: {youtube_video}")
+                print("There was an error with video: {}".format(youtube_video))
                 print(e)
     else:
         print("Loading video...")
@@ -156,7 +156,7 @@ def build_playback_report(youtube: YouTube) -> None:
         A YouTube object.
     """
     ts = int(dt.datetime.utcnow().timestamp())
-    fp = os.path.join(os.getcwd(), f"yt-video-{youtube.video_id}-{ts}.json.gz")
+    fp = os.path.join(os.getcwd(), "yt-video-{}-{}.json.gz".format(youtube.video_id, ts))
 
     js = youtube.js
     watch_html = youtube.watch_html
@@ -203,7 +203,7 @@ def display_progress_bar(
     remaining = max_width - filled
     progress_bar = ch * filled + " " * remaining
     percent = round(100.0 * bytes_received / float(filesize), 1)
-    text = f" ↳ |{progress_bar}| {percent}%\r"
+    text = " ↳ |{}| {}%\r".format(progress_bar, percent)
     sys.stdout.write(text)
     sys.stdout.flush()
 
@@ -221,10 +221,10 @@ def _download(
     stream: Stream, target: Optional[str] = None, filename: Optional[str] = None
 ) -> None:
     filesize_megabytes = stream.filesize // 1048576
-    print(f"{filename or stream.default_filename} | {filesize_megabytes} MB")
+    print("{} | {} MB".format(filename or stream.default_filename, filesize_megabytes))
     file_path = stream.get_file_path(filename=filename, output_path=target)
     if stream.exists_at_path(file_path):
-        print(f"Already downloaded at:\n{file_path}")
+        print("Already downloaded at:\n{}".format(file_path))
         return
 
     stream.download(output_path=target, filename=filename)
@@ -246,8 +246,8 @@ def _unique_name(base: str, subtype: str, media_type: str, target: str) -> str:
     """
     counter = 0
     while True:
-        file_name = f"{base}_{media_type}_{counter}"
-        file_path = os.path.join(target, f"{file_name}.{subtype}")
+        file_name = "{}_{}_{}".format(base, media_type, counter)
+        file_path = os.path.join(target, "{}.{}".format(file_name, subtype))
         if not os.path.exists(file_path):
             return file_name
         counter += 1
@@ -291,7 +291,7 @@ def ffmpeg_process(
                 progressive=False, resolution=resolution
             ).first()
     if video_stream is None:
-        print(f"Could not find a stream with resolution: {resolution}")
+        print("Could not find a stream with resolution: {}".format(resolution))
         print("Try one of these:")
         display_streams(youtube)
         sys.exit()
@@ -331,10 +331,10 @@ def _ffmpeg_downloader(audio_stream: Stream, video_stream: Stream, target: str) 
     print("Loading audio...")
     _download(stream=audio_stream, target=target, filename=audio_unique_name)
 
-    video_path = os.path.join(target, f"{video_unique_name}.{video_stream.subtype}")
-    audio_path = os.path.join(target, f"{audio_unique_name}.{audio_stream.subtype}")
+    video_path = os.path.join(target, "{}.{}".format(video_unique_name, video_stream.subtype))
+    audio_path = os.path.join(target, "{}.{}".format(audio_unique_name, audio_stream.subtype))
     final_path = os.path.join(
-        target, f"{safe_filename(video_stream.title)}.{video_stream.subtype}"
+        target, "{}.{}".format(safe_filename(video_stream.title), video_stream.subtype)
     )
 
     subprocess.run(  # nosec
@@ -356,7 +356,7 @@ def download_by_itag(youtube: YouTube, itag: int, target: Optional[str] = None) 
     """
     stream = youtube.streams.get_by_itag(itag)
     if stream is None:
-        print(f"Could not find a stream with itag: {itag}")
+        print("Could not find a stream with itag: {}".format(itag))
         print("Try one of these:")
         display_streams(youtube)
         sys.exit()
@@ -384,7 +384,7 @@ def download_by_resolution(
     # TODO(nficano): allow dash itags to be selected
     stream = youtube.streams.get_by_resolution(resolution)
     if stream is None:
-        print(f"Could not find a stream with resolution: {resolution}")
+        print("Could not find a stream with resolution: {}".format(resolution))
         print("Try one of these:")
         display_streams(youtube)
         sys.exit()
@@ -409,7 +409,7 @@ def display_streams(youtube: YouTube) -> None:
 
 
 def _print_available_captions(captions: CaptionQuery) -> None:
-    print(f"Available caption codes are: {', '.join(c.code for c in captions)}")
+    print("Available caption codes are: {}".format(', '.join(c.code for c in captions)))
 
 
 def download_caption(
@@ -433,9 +433,9 @@ def download_caption(
     try:
         caption = youtube.captions[lang_code]
         downloaded_path = caption.download(title=youtube.title, output_path=target)
-        print(f"Saved caption file to: {downloaded_path}")
+        print("Saved caption file to: {}".format(downloaded_path))
     except KeyError:
-        print(f"Unable to find caption with code: {lang_code}")
+        print("Unable to find caption with code: {}".format(lang_code))
         _print_available_captions(youtube.captions)
 
 

--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -186,10 +186,10 @@ class Playlist(Sequence):
     )
     def download_all(
         self,
-        download_path: Optional[str] = None,
-        prefix_number: bool = True,
-        reverse_numbering: bool = False,
-        resolution: str = "720p",
+        download_path = None,
+        prefix_number = True,
+        reverse_numbering = False,
+        resolution = "720p",
     ) -> None:  # pragma: no cover
         """Download all the videos in the the playlist.
 

--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -28,7 +28,7 @@ class Playlist(Sequence):
         except IndexError:  # assume that url is just the id
             self.playlist_id = url
 
-        self.playlist_url = f"https://www.youtube.com/playlist?list={self.playlist_id}"
+        self.playlist_url = "https://www.youtube.com/playlist?list={}".format(self.playlist_id)
         self.html = request.get(self.playlist_url)
 
         # Needs testing with non-English
@@ -39,7 +39,7 @@ class Playlist(Sequence):
         if date_match:
             month, day, year = date_match.groups()
             self.last_update = datetime.strptime(
-                f"{month} {day:0>2} {year}", "%b %d %Y"
+                "{month} {day:0>2} {year}", "%b %d %Y"
             ).date()
 
         self._video_regex = re.compile(r"href=\"(/watch\?v=[\w-]*)")
@@ -52,7 +52,7 @@ class Playlist(Sequence):
             req,
         )
         if match:
-            return f"https://www.youtube.com{match.group(1)}"
+            return "https://www.youtube.com{}".format(match.group(1))
 
         return None
 
@@ -71,7 +71,7 @@ class Playlist(Sequence):
         videos_urls = self._extract_videos(req)
         if until_watch_id:
             try:
-                trim_index = videos_urls.index(f"/watch?v={until_watch_id}")
+                trim_index = videos_urls.index("/watch?v={}".format(until_watch_id))
                 yield videos_urls[:trim_index]
                 return
             except ValueError:
@@ -94,7 +94,7 @@ class Playlist(Sequence):
             videos_urls = self._extract_videos(html)
             if until_watch_id:
                 try:
-                    trim_index = videos_urls.index(f"/watch?v={until_watch_id}")
+                    trim_index = videos_urls.index("/watch?v={}".format(until_watch_id))
                     yield videos_urls[:trim_index]
                     return
                 except ValueError:
@@ -150,7 +150,7 @@ class Playlist(Sequence):
         return len(self.video_urls)
 
     def __repr__(self) -> str:
-        return f"{self.video_urls}"
+        return repr(self.video_urls)
 
     @deprecated(
         "This call is unnecessary, you can directly access .video_urls or .videos"
@@ -249,4 +249,4 @@ class Playlist(Sequence):
 
     @staticmethod
     def _video_url(watch_path: str):
-        return f"https://www.youtube.com{watch_path}"
+        return "https://www.youtube.com{}".format(watch_path)

--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -24,7 +24,7 @@ class Playlist(Sequence):
             install_proxy(proxies)
 
         try:
-            self.playlist_id: str = parse_qs(url.split("?")[1])["list"][0]
+            self.playlist_id = parse_qs(url.split("?")[1])["list"][0]
         except IndexError:  # assume that url is just the id
             self.playlist_id = url
 
@@ -32,7 +32,7 @@ class Playlist(Sequence):
         self.html = request.get(self.playlist_url)
 
         # Needs testing with non-English
-        self.last_update: Optional[date] = None
+        self.last_update = None
         date_match = re.search(
             r"<li>Last updated on (\w{3}) (\d{1,2}), (\d{4})</li>", self.html
         )

--- a/pytube/exceptions.py
+++ b/pytube/exceptions.py
@@ -27,7 +27,7 @@ class RegexMatchError(ExtractError):
         :param str pattern:
             Pattern that failed to match
         """
-        super().__init__(f"{caller}: could not find match for {pattern}")
+        super().__init__("{}: could not find match for {}".format(caller, pattern))
         self.caller = caller
         self.pattern = pattern
 
@@ -40,7 +40,7 @@ class LiveStreamError(ExtractError):
         :param str video_id:
             A YouTube video identifier.
         """
-        super().__init__(f"{video_id} is streaming live and cannot be loaded")
+        super().__init__("{} is streaming live and cannot be loaded".format(video_id))
 
         self.video_id = video_id
 
@@ -53,7 +53,7 @@ class VideoUnavailable(PytubeError):
         :param str video_id:
             A YouTube video identifier.
         """
-        super().__init__(f"{video_id} is unavailable")
+        super().__init__("{} is unavailable".format(video_id))
 
         self.video_id = video_id
 

--- a/pytube/extract.py
+++ b/pytube/extract.py
@@ -227,7 +227,7 @@ def apply_signature(config_args: Dict, fmt: str, js: str) -> None:
 
     for i, stream in enumerate(stream_manifest):
         try:
-            url: str = stream["url"]
+            url = stream["url"]
         except KeyError:
             live_stream = (
                 json.loads(config_args["player_response"])

--- a/pytube/extract.py
+++ b/pytube/extract.py
@@ -37,7 +37,7 @@ class PytubeHTMLParser(HTMLParser):
 
     def handle_data(self, data):
         if self.in_vid_descr_br:
-            self.vid_descr += f"\n{data}"
+            self.vid_descr += "\n{}".format(data)
             self.in_vid_descr_br = False
         elif self.in_vid_descr:
             self.vid_descr += data
@@ -122,7 +122,7 @@ def video_info_url_age_restricted(video_id: str, embed_html: str) -> str:
         sts = ""
     # Here we use ``OrderedDict`` so that the output is consistent between
     # Python 2.7+.
-    eurl = f"https://youtube.googleapis.com/v/{video_id}"
+    eurl = "https://youtube.googleapis.com/v/{}".format(video_id)
     params = OrderedDict([("video_id", video_id), ("eurl", eurl), ("sts", sts),])
     return _video_info_url(params)
 

--- a/pytube/helpers.py
+++ b/pytube/helpers.py
@@ -162,7 +162,7 @@ def install_proxy(proxy_handler: Dict[str, str]) -> None:
 
 
 def uniqueify(duped_list: List) -> List:
-    seen: Dict[Any, bool] = {}
+    seen = {}
     result = []
     for item in duped_list:
         if item in seen:

--- a/pytube/monostate.py
+++ b/pytube/monostate.py
@@ -43,8 +43,8 @@ class Monostate:
         self,
         on_progress: Optional[OnProgress],
         on_complete: Optional[OnComplete],
-        title: Optional[str] = None,
-        duration: Optional[int] = None,
+        title = None,
+        duration = None,
     ):
         self.on_progress = on_progress
         self.on_complete = on_complete

--- a/pytube/query.py
+++ b/pytube/query.py
@@ -353,7 +353,7 @@ class StreamQuery(Sequence):
         return len(self.fmt_streams)
 
     def __repr__(self) -> str:
-        return f"{self.fmt_streams}"
+        return "{}".format(self.fmt_streams)
 
 
 class CaptionQuery(Mapping):
@@ -402,4 +402,4 @@ class CaptionQuery(Mapping):
         return iter(self.lang_code_index.values())
 
     def __repr__(self) -> str:
-        return f"{self.lang_code_index}"
+        return "{}".format(self.lang_code_index)

--- a/pytube/request.py
+++ b/pytube/request.py
@@ -49,7 +49,7 @@ def stream(
     downloaded = 0
     while downloaded < file_size:
         stop_pos = min(downloaded + range_size, file_size) - 1
-        range_header = f"bytes={downloaded}-{stop_pos}"
+        range_header = "bytes={}-{}".format(downloaded, stop_pos)
         response = _execute_request(url, method="GET", headers={"Range": range_header})
         if file_size == range_size:
             try:

--- a/pytube/request.py
+++ b/pytube/request.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 def _execute_request(
-    url: str, method: Optional[str] = None, headers: Optional[Dict[str, str]] = None
+    url: str, method: Optional[str] = None, headers = None
 ) -> HTTPResponse:
     base_headers = {"User-Agent": "Mozilla/5.0"}
     if headers:
@@ -37,7 +37,7 @@ def get(url) -> str:
 
 
 def stream(
-    url: str, chunk_size: int = 4096, range_size: int = 9437184
+    url: str, chunk_size: int = 4096, range_size = 9437184
 ) -> Iterable[bytes]:
     """Read the response in chunks.
     :param str url: The URL to perform the GET request for.
@@ -45,7 +45,7 @@ def stream(
     :param int range_size: The size in bytes of each range request. Defaults to 9MB
     :rtype: Iterable[bytes]
     """
-    file_size: int = range_size  # fake filesize to start
+    file_size = range_size  # fake filesize to start
     downloaded = 0
     while downloaded < file_size:
         stop_pos = min(downloaded + range_size, file_size) - 1

--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -185,7 +185,7 @@ class Stream:
             An os file system compatible filename.
         """
         filename = safe_filename(self.title)
-        return f"{filename}.{self.subtype}"
+        return "{}.{}".format(filename, self.subtype)
 
     def download(
         self,
@@ -249,11 +249,11 @@ class Stream:
         filename_prefix: Optional[str] = None,
     ) -> str:
         if filename:
-            filename = f"{safe_filename(filename)}.{self.subtype}"
+            filename = "{}.{}".format(safe_filename(filename), self.subtype)
         else:
             filename = self.default_filename
         if filename_prefix:
-            filename = f"{safe_filename(filename_prefix)}{filename}"
+            filename = "{}{}".format(safe_filename(filename_prefix), filename)
         return os.path.join(target_directory(output_path), filename)
 
     def exists_at_path(self, file_path: str) -> bool:
@@ -336,4 +336,4 @@ class Stream:
         else:
             parts.extend(['abr="{s.abr}"', 'acodec="{s.audio_codec}"'])
         parts.extend(['progressive="{s.is_progressive}"', 'type="{s.type}"'])
-        return f"<Stream: {' '.join(parts).format(s=self)}>"
+        return "<Stream: {}>".format(' '.join(parts).format(s=self))

--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -58,10 +58,10 @@ class Stream:
         # streams return NoneType for audio/video depending.
         self.video_codec, self.audio_codec = self.parse_codecs()
 
-        self.is_otf: bool = stream["is_otf"]
-        self.bitrate: Optional[int] = stream["bitrate"]
+        self.is_otf = stream["is_otf"]
+        self.bitrate = stream["bitrate"]
 
-        self._filesize: Optional[int] = None  # filesize in bytes
+        self._filesize = None  # filesize in bytes
 
         # Additional information about the stream format, such as resolution,
         # frame rate, and whether the stream is live (HLS) or 3D.

--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -189,10 +189,10 @@ class Stream:
 
     def download(
         self,
-        output_path: Optional[str] = None,
-        filename: Optional[str] = None,
-        filename_prefix: Optional[str] = None,
-        skip_existing: bool = True,
+        output_path = None,
+        filename = None,
+        filename_prefix = None,
+        skip_existing = True,
     ) -> str:
         """Write the media stream to disk.
 
@@ -246,7 +246,7 @@ class Stream:
         self,
         filename: Optional[str],
         output_path: Optional[str],
-        filename_prefix: Optional[str] = None,
+        filename_prefix = None,
     ) -> str:
         if filename:
             filename = "{}.{}".format(safe_filename(filename), self.subtype)

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         "Operating System :: Microsoft",
         "Operating System :: POSIX",
         "Operating System :: Unix",
+        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
@@ -49,7 +50,7 @@ setup(
     long_description_content_type="text/markdown",
     long_description=long_description,
     zip_safe=True,
-    python_requires=">=3.6",
+    python_requires=">=3.5",
     project_urls={
         "Bug Reports": "https://github.com/hbmartin/pytube3/issues",
         "Read the Docs": "https://pytube3.readthedocs.io/en/latest/?badge=latest",


### PR DESCRIPTION
I know features of 3.7 and newer are sexy and everyone loves using them. Unfortunately there are a lot of devices supporting only version 3.5 of python. For my personal usage I made this library backward compatible, but maybe there is also interest to bring this "downgrade" also to master.