### PR TITLE
Fallback to index "signatureCipher"

### DIFF
--- a/pytube/extract.py
+++ b/pytube/extract.py
@@ -297,9 +297,10 @@ def apply_descrambler(stream_data: Dict, key: str) -> None:
                 for format_item in formats
             ]
         except KeyError:
-            cipher_url = [
-                parse_qs(formats[i]["cipher"]) for i, data in enumerate(formats)
-            ]
+            cipher_url = []
+            for data in formats:
+                cipher = data.get("cipher") or data["signatureCipher"]
+                cipher_url.append(parse_qs(cipher))
             stream_data[key] = [
                 {
                     "url": cipher_url[i]["url"][0],


### PR DESCRIPTION
It seems like YouTube recently changed the key name for "cipher" to
"signatureCipher" and PyTube has been failing because of this.

With this commit, PyTube will fallback to check for the value for
"signatureCipher" when the value for "cipher" is not available.
This is similar to how youtube-dl checks for this too
(in https://github.com/ytdl-org/youtube-dl/blob/228c1d685bb6d35b2c1a73e1adbc085c76da6b75/youtube_dl/extractor/youtube.py#L1977).

Fixes #641.