### PR TITLE
Fix for issue: https://github.com/nficano/pytube/issues/661 and default video titles not being shown

### DIFF
--- a/pytube/extract.py
+++ b/pytube/extract.py
@@ -315,7 +315,7 @@ def apply_descrambler(stream_data: Dict, key: str) -> None:
             ]
         except KeyError:
             cipher_url = [
-                parse_qs(formats[i]["cipher"])
+                parse_qs(formats[i]["signatureCipher"])
                 for i, data in enumerate(formats)
             ]
             stream_data[key] = [


### PR DESCRIPTION
Address the issue: 
KeyError: 'url' and KeyError: 'cipher' ,please someone update this code or some procedure to fix my code #661
Link: https://github.com/nficano/pytube/issues/661

Cause of the issue:
Youtube has modified json response for the streams and replaced "cipher" key with "signatureCipher".

Other changes:
Youtube has begun to send titles of the video in <meta> tags. So, I have extracted titles from <meta> tags.