### PR TITLE
Adapt playlist extraction to YouTubes architectual changes

### DIFF
--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -6,7 +6,7 @@ import re
 from collections.abc import Sequence
 from datetime import date
 from datetime import datetime
-from typing import Dict
+from typing import Dict, Tuple
 from typing import Iterable
 from typing import List
 from typing import Optional
@@ -51,20 +51,11 @@ class Playlist(Sequence):
                 f"{month} {day:0>2} {year}", "%b %d %Y"
             ).date()
 
-        self._video_regex = re.compile(r"href=\"(/watch\?v=[\w-]*)")
-
-    @staticmethod
-    def _find_load_more_url(req: str) -> Optional[str]:
-        """Given an html page or fragment, returns the "load more" url if found."""
-        match = re.search(
-            r"data-uix-load-more-href=\"(/browse_ajax\?"
-            'action_continuation=.*?)"',
-            req,
+        self._js_regex = re.compile(
+            r"window\[\"ytInitialData\"] = ([^\n]+)"
         )
-        if match:
-            return f"https://www.youtube.com{match.group(1)}"
 
-        return None
+        self._video_regex = re.compile(r"href=\"(/watch\?v=[\w-]*)")
 
     @deprecated(
         "This function will be removed in the future, please use .video_urls"
@@ -76,60 +67,101 @@ class Playlist(Sequence):
         """
         return self.video_urls
 
+    def _extract_json(self, html: str) -> str:
+        return self._js_regex.search(html).group(1)[0:-1]
+
     def _paginate(
-        self, until_watch_id: Optional[str] = None
+            self, until_watch_id: Optional[str] = None
     ) -> Iterable[List[str]]:
-        """Parse the video links from the page source, yields the /watch?v= part from video link
+        """Parse the video links from the page source, yields the /watch?v=
+        part from video link
         """
         req = self.html
-        videos_urls = self._extract_videos(req)
-        if until_watch_id:
-            try:
-                trim_index = videos_urls.index(f"/watch?v={until_watch_id}")
-                yield videos_urls[:trim_index]
-                return
-            except ValueError:
-                pass
+        videos_urls, continuation = self._extract_videos(
+            self._extract_json(req))
         yield videos_urls
 
         # The above only returns 100 or fewer links
         # Simulating a browser request for the load more link
-        load_more_url = self._find_load_more_url(req)
+        if continuation:
+            load_more_url, headers = self._build_continuation_url(
+                continuation)
+        else:
+            load_more_url, headers = None, None
 
-        while load_more_url:  # there is an url found
+        while load_more_url and headers:  # there is an url found
             logger.debug("load more url: %s", load_more_url)
-            req = request.get(load_more_url)
-            load_more = json.loads(req)
-            try:
-                html = load_more["content_html"]
-            except KeyError:
-                logger.debug("Could not find content_html")
-                return
-            videos_urls = self._extract_videos(html)
-            if until_watch_id:
-                try:
-                    trim_index = videos_urls.index(
-                        f"/watch?v={until_watch_id}"
-                    )
-                    yield videos_urls[:trim_index]
-                    return
-                except ValueError:
-                    pass
+            req = request.get(load_more_url, extra_headers=headers)
+            videos_urls, continuation = self._extract_videos(req)
             yield videos_urls
 
-            load_more_url = self._find_load_more_url(
-                load_more["load_more_widget_html"],
-            )
+            if continuation:
+                load_more_url, headers = self._build_continuation_url(
+                    continuation)
+            else:
+                load_more_url, headers = None, None
 
         return
 
-    def _extract_videos(self, html: str) -> List[str]:
-        return uniqueify(self._video_regex.findall(html))
+    @staticmethod
+    def _build_continuation_url(continuation: str) -> Tuple[str, dict]:
+        """
+        Returns url, headers
+        """
+        return f"https://www.youtube.com/browse_ajax?ctoken=" \
+               f"{continuation}&continuation={continuation}", \
+               {
+                   "X-YouTube-Client-Name": "1",
+                   "X-YouTube-Client-Version": "2.20200720.00.02",
+               }
+
+    @staticmethod
+    def _extract_videos(raw_json: str) -> Tuple[List[str], Optional[str]]:
+        """
+        @returns: List[endpoint], Continuation[Optional]]
+        """
+        initial_data = json.loads(raw_json)
+        try:
+            important_content = \
+                initial_data["contents"]["twoColumnBrowseResultsRenderer"][
+                    "tabs"][
+                    0][
+                    "tabRenderer"]["content"]["sectionListRenderer"][
+                    "contents"][0][
+                    "itemSectionRenderer"]["contents"][0][
+                    "playlistVideoListRenderer"]
+        except (KeyError, IndexError, TypeError):
+            try:
+                important_content = \
+                    initial_data[1]["response"][
+                        "continuationContents"][
+                        "playlistVideoListContinuation"]
+            except (KeyError, IndexError, TypeError) as p:
+                print(p)
+                return [], None
+        videos = important_content["contents"]
+        try:
+            continuation = \
+                important_content["continuations"][0]["nextContinuationData"][
+                    "continuation"]
+        except (KeyError, IndexError):
+            continuation = None
+
+        return uniqueify(
+            list(
+                map(
+                    lambda x: (
+                        f"/watch?id={x['playlistVideoRenderer']['videoId']}"),
+                    videos
+                )
+            )
+        ), continuation
 
     def trimmed(self, video_id: str) -> Iterable[str]:
         """Retrieve a list of YouTube video URLs trimmed at the given video ID
 
-        i.e. if the playlist has video IDs 1,2,3,4 calling trimmed(3) returns [1,2]
+        i.e. if the playlist has video IDs 1,2,3,4 calling trimmed(3) returns
+        [1,2]
         :type video_id: str
             video ID to trim the returned list of playlist URLs at
         :rtype: List[str]
@@ -171,7 +203,8 @@ class Playlist(Sequence):
         return f"{self.video_urls}"
 
     @deprecated(
-        "This call is unnecessary, you can directly access .video_urls or .videos"
+        "This call is unnecessary, you can directly access .video_urls or "
+        ".videos"
     )
     def populate_video_urls(self) -> List[str]:  # pragma: no cover
         """Complete links of all the videos in playlist
@@ -200,14 +233,15 @@ class Playlist(Sequence):
         return (str(i).zfill(digits) for i in range(start, stop, step))
 
     @deprecated(
-        "This function will be removed in the future. Please iterate through .videos"
+        "This function will be removed in the future. Please iterate through "
+        ".videos"
     )
     def download_all(
-        self,
-        download_path: Optional[str] = None,
-        prefix_number: bool = True,
-        reverse_numbering: bool = False,
-        resolution: str = "720p",
+            self,
+            download_path: Optional[str] = None,
+            prefix_number: bool = True,
+            reverse_numbering: bool = False,
+            resolution: str = "720p",
     ) -> None:  # pragma: no cover
         """Download all the videos in the the playlist.
 
@@ -236,8 +270,8 @@ class Playlist(Sequence):
         for link in self.video_urls:
             youtube = YouTube(link)
             dl_stream = (
-                youtube.streams.get_by_resolution(resolution=resolution)
-                or youtube.streams.get_lowest_resolution()
+                    youtube.streams.get_by_resolution(resolution=resolution)
+                    or youtube.streams.get_lowest_resolution()
             )
             assert dl_stream is not None
 

--- a/pytube/request.py
+++ b/pytube/request.py
@@ -13,9 +13,9 @@ logger = logging.getLogger(__name__)
 
 
 def _execute_request(
-    url: str,
-    method: Optional[str] = None,
-    headers: Optional[Dict[str, str]] = None,
+        url: str,
+        method: Optional[str] = None,
+        headers: Optional[Dict[str, str]] = None,
 ) -> HTTPResponse:
     base_headers = {"User-Agent": "Mozilla/5.0"}
     if headers:
@@ -27,25 +27,30 @@ def _execute_request(
     return urlopen(request)  # nosec
 
 
-def get(url) -> str:
+def get(url, extra_headers=None) -> str:
     """Send an http GET request.
 
     :param str url:
         The URL to perform the GET request for.
+    :param dict extra_headers:
+        Extra headers to add to the request
     :rtype: str
     :returns:
         UTF-8 encoded string of response
     """
-    return _execute_request(url).read().decode("utf-8")
+    if extra_headers is None:
+        extra_headers = {}
+    return _execute_request(url, headers=extra_headers).read().decode("utf-8")
 
 
 def stream(
-    url: str, chunk_size: int = 4096, range_size: int = 9437184
+        url: str, chunk_size: int = 4096, range_size: int = 9437184
 ) -> Iterable[bytes]:
     """Read the response in chunks.
     :param str url: The URL to perform the GET request for.
     :param int chunk_size: The size in bytes of each chunk. Defaults to 4KB
-    :param int range_size: The size in bytes of each range request. Defaults to 9MB
+    :param int range_size: The size in bytes of each range request. Defaults
+    to 9MB
     :rtype: Iterable[bytes]
     """
     file_size: int = range_size  # fake filesize to start


### PR DESCRIPTION
This PR addresses multiple errors with playlist video extraction. 

Fixes: #684 
Fixes: #670 

and possibly other issues.

This PR is necessary, because YouTube recently changed something at their backand which changed the format of the playlist html responses, so the old way of extracting the youtube urls won't work anymore.

YouTube is now relying on putting all relevant information inside a js variable and populating the site via html. 

The corresponding js var is window["ytInitialData"] and contains json data about anything which should be displayed on the page.

The videos are now listed inside the json variable and can easily be extracted via json "tree-walking" as shown in the code. (I can add comments if neccessary, just add a change request thingie).

Another thing that changed was the way continuations/pagination works now. Before the update, getting the urls from a playlist with more than 100 songs was fairly simple, because the page contained the url which contained the next page of videos.
YouTube replaced this with a ajax api endpoint call, which needs a continuation token. This token can be extracted from the json as well as shown in the code. 
This ajax endpoint also needs some headers now (don't ask me why, I simpy found them by looking inside the developer tools and stripped the unnecessary). 
These are also included inside the code.
This endpoint contains similar data to the data initially provided inside the html page of the playlist.

This update by YouTube has a positive impact on performance of long playlists, because downloading a json is using way less time and bandwidth than downloading the entire website and extracting the urls via regex.