### PR TITLE
Fix typo in playlist video urls

### DIFF
--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -196,7 +196,7 @@ class Playlist(Sequence):
                 # only extract the video ids from the video data
                 map(
                     lambda x: (
-                        f"/watch?id={x['playlistVideoRenderer']['videoId']}"),
+                        f"/watch?v={x['playlistVideoRenderer']['videoId']}"),
                     videos
                 )
             )


### PR DESCRIPTION
In my PR, which was merged yesterday (#687) I included a typo, which would format the videos extracted from a playlist as https://youtube.com/watch?id={video_id} instead of https://youtube.com/watch?v={video_id}.

This is a breaking issue and should be merged quickly.