### PR TITLE
[fix] improve pattern matching

### DIFF
--- a/pytube/extract.py
+++ b/pytube/extract.py
@@ -196,7 +196,6 @@ def get_ytplayer_config(html: str) -> Any:
         Substring of the html containing the encoded manifest data.
     """
     config_patterns = [
-        r";ytplayer\.config\s*=\s*({.*?});",
         r";ytplayer\.config\s*=\s*({.+?});ytplayer",
         r";yt\.setConfig\(\{'PLAYER_CONFIG':\s*({.*})}\);",
         r";yt\.setConfig\(\{'PLAYER_CONFIG':\s*({.*})(,'EXPERIMENT_FLAGS'|;)",  # noqa: E501


### PR DESCRIPTION
Issue 724 complains about an unterminated string.
While investigating I bumped upon the following patterns in extract.py
         r";ytplayer\.config\s*=\s*({.*?});",
         r";ytplayer\.config\s*=\s*({.+?});ytplayer",
This seems odd to me. If the first pattern does not match, then the
second won't mach either.

The unterminated string suggests that perhaps the first match is too
short as *? is non-greedy matching.
Of course if this happens or not depends on the actual html ouput that
is sent by youtube.

As a test I decided to remove the first pattern, since the config string
I got back had ;ytplayer after it. Keeping the + seems ok, as an empty
string does not seem a valid result.

Without the patch about 1 out of 5 downloads failed for me.
With the patch about 150 downloads have been done, all successful.

pytest passes
pep8 is not run as only a line in an array is removed

Closes: #724