### PR TITLE
Removed  "self" from on complete function.

### DIFF
--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -336,7 +336,7 @@ class Stream:
         on_complete = self._monostate.on_complete
         if on_complete:
             logger.debug("calling on_complete callback %s", on_complete)
-            on_complete(self, file_path)
+            on_complete(file_path)
 
     def __repr__(self) -> str:
         """Printable object representation.


### PR DESCRIPTION
Removed self from on_complete function because 
The on_complete function takes self as an arg rather than taking as an instance of the class and returns in on_complete_callback ( line: 336, file: pytube/__main__.py) as an arg, which causes problem as call back function  ( line: 336, file: pytube/__main__.py) takes it (self) as an arg and returns it as arg for the function which is to be executed after the download and this causes error in script with classes and throws Positional Argument Errors.
Thus breaking the code.

Removing self from on_complete does not break any part of code (tested), and the function on_complete_callback which was throwing error first is now resolved.