### PR TITLE
Changed platform-specific separators to platform-agnostic separators.

### DIFF
--- a/tests/test_captions.py
+++ b/tests/test_captions.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import os
 from unittest import mock
 from unittest.mock import MagicMock
 from unittest.mock import mock_open
@@ -71,7 +72,7 @@ def test_download(srt):
         )
         caption.download("title")
         assert (
-            open_mock.call_args_list[0][0][0].split("/")[-1] == "title (en).srt"
+            open_mock.call_args_list[0][0][0].split(os.path.sep)[-1] == "title (en).srt"
         )
 
 
@@ -89,7 +90,7 @@ def test_download_with_prefix(srt):
         )
         caption.download("title", filename_prefix="1 ")
         assert (
-            open_mock.call_args_list[0][0][0].split("/")[-1]
+            open_mock.call_args_list[0][0][0].split(os.path.sep)[-1]
             == "1 title (en).srt"
         )
 
@@ -108,7 +109,7 @@ def test_download_with_output_path(srt):
             }
         )
         file_path = caption.download("title", output_path="blah")
-        assert file_path == "/target/title (en).srt"
+        assert file_path == os.path.join("/target", "title (en).srt")
         captions.target_directory.assert_called_with("blah")
 
 
@@ -126,7 +127,7 @@ def test_download_xml_and_trim_extension(xml):
         )
         caption.download("title.xml", srt=False)
         assert (
-            open_mock.call_args_list[0][0][0].split("/")[-1] == "title (en).xml"
+            open_mock.call_args_list[0][0][0].split(os.path.sep)[-1] == "title (en).xml"
         )
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import os
 from unittest import mock
 
 import pytest
@@ -61,7 +62,7 @@ def test_cache():
 @mock.patch("os.getcwd", return_value="/cwd")
 @mock.patch("os.makedirs")
 def test_target_directory_with_relative_path(_, __, makedirs):  # noqa: PT019
-    assert target_directory("test") == "/cwd/test"
+    assert target_directory("test") == os.path.join("/cwd", "test")
     makedirs.assert_called()
 
 

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -149,7 +149,10 @@ def test_download_with_prefix(cipher_signature):
     with mock.patch("pytube.streams.open", mock.mock_open(), create=True):
         stream = cipher_signature.streams[0]
         file_path = stream.download(filename_prefix="prefix")
-        assert file_path == "/target/prefixPSY - GANGNAM STYLE(강남스타일) MV.mp4"
+        assert file_path == os.path.join(
+            "/target",
+            "prefixPSY - GANGNAM STYLE(강남스타일) MV.mp4"
+        )
 
 
 @mock.patch(
@@ -164,7 +167,7 @@ def test_download_with_filename(cipher_signature):
     with mock.patch("pytube.streams.open", mock.mock_open(), create=True):
         stream = cipher_signature.streams[0]
         file_path = stream.download(filename="cool name bro")
-        assert file_path == "/target/cool name bro.mp4"
+        assert file_path == os.path.join("/target", "cool name bro.mp4")
 
 
 @mock.patch(
@@ -181,7 +184,10 @@ def test_download_with_existing(cipher_signature):
         stream = cipher_signature.streams[0]
         os.path.getsize = Mock(return_value=stream.filesize)
         file_path = stream.download()
-        assert file_path == "/target/PSY - GANGNAM STYLE(강남스타일) MV.mp4"
+        assert file_path == os.path.join(
+            "/target",
+            "PSY - GANGNAM STYLE(강남스타일) MV.mp4"
+        )
         assert not request.stream.called
 
 
@@ -199,7 +205,10 @@ def test_download_with_existing_no_skip(cipher_signature):
         stream = cipher_signature.streams[0]
         os.path.getsize = Mock(return_value=stream.filesize)
         file_path = stream.download(skip_existing=False)
-        assert file_path == "/target/PSY - GANGNAM STYLE(강남스타일) MV.mp4"
+        assert file_path == os.path.join(
+            "/target",
+            "PSY - GANGNAM STYLE(강남스타일) MV.mp4"
+        )
         assert request.stream.called
 
 


### PR DESCRIPTION
Attempting to run the test suites locally on a windows machine causes some issues with how path separators are evaluated. This fixes that issue by replacing references to `"/"` with references to `os.path.sep`, and uses `os.path.join()` for creating the paths.