### PR TITLE
Added continue-on-error to greeting action.

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/first-interaction@v1
+      continue-on-error: true
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         issue-message: 'Thank you for contributing to PyTube. Please remember to reference [Contributing.md](https://github.com/nficano/pytube/blob/master/Contributing.md)'


### PR DESCRIPTION
This action isn't something that should cause merge issues if it fails. Adding the continue-on-error attribute to the `first-interaction` action will prevent this from happening.