### PR TITLE
Fix #797

### DIFF
--- a/pytube/cipher.py
+++ b/pytube/cipher.py
@@ -247,7 +247,7 @@ def splice(arr: List, b: int):
     >>> splice([1, 2, 3, 4], 2)
     [1, 2]
     """
-    return arr[:b]
+    return arr[b:]
 
 
 def swap(arr: List, b: int):

--- a/pytube/extract.py
+++ b/pytube/extract.py
@@ -274,7 +274,6 @@ def get_ytplayer_config(html: str) -> Any:
             yt_config = function_match.group(1)
             return json.loads(yt_config)['PLAYER_CONFIG']
 
-
     raise RegexMatchError(
         caller="get_ytplayer_config", pattern="config_patterns, setconfig_patterns"
     )

--- a/tests/test_cipher.py
+++ b/tests/test_cipher.py
@@ -26,5 +26,5 @@ def test_reverse():
 
 
 def test_splice():
-    assert cipher.splice([1, 2, 3, 4], 2) == [1, 2]
-    assert cipher.splice([1, 2, 3, 4], 1) == [1]
+    assert cipher.splice([1, 2, 3, 4], 2) == [3, 4]
+    assert cipher.splice([1, 2, 3, 4], 1) == [2, 3, 4]

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -121,7 +121,7 @@ def test_create_mock_html_json(mock_url_open, mock_open):
     # 2. vid_info_raw
     # 3. js
     mock_url_open_object.read.side_effect = [
-        b'"jsUrl":"base.js"',
+        b'yt.setConfig({"PLAYER_CONFIG":{"args":[]}});"jsUrl":"/s/player/13371337/player_ias.vflset/en_US/base.js"',
         b'vid_info_raw',
         b'js_result',
     ]

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -121,7 +121,8 @@ def test_create_mock_html_json(mock_url_open, mock_open):
     # 2. vid_info_raw
     # 3. js
     mock_url_open_object.read.side_effect = [
-        b'yt.setConfig({"PLAYER_CONFIG":{"args":[]}});"jsUrl":"/s/player/13371337/player_ias.vflset/en_US/base.js"',
+        (b'yt.setConfig({"PLAYER_CONFIG":{"args":[]}});'
+         b'"jsUrl":"/s/player/13371337/player_ias.vflset/en_US/base.js"'),
         b'vid_info_raw',
         b'js_result',
     ]


### PR DESCRIPTION
pytube uses embed html to bypass age restrictions on content, but embed html behaves differently. This PR fixes a few different issues, so that pytube can extract the jsurl correctly. Currently incomplete, as there is now a 403 error, working on that next.