### PR TITLE
Improvement/reduce network calls

### DIFF
--- a/docs/user/playlist.rst
+++ b/docs/user/playlist.rst
@@ -39,8 +39,8 @@ Or, if we're only interested in the URLs for the videos, we can look at those as
 
     >>> for url in p.video_urls[:3]:
     >>>     print(url)
-    Python Tutorial for Beginers 1 - Getting Started and Installing Python (For Absolute Beginners)
-    Python Tutorial for Beginers 2 - Numbers and Math in Python
-    Python Tutorial for Beginers 3 - Variables and Inputs
+    Python Tutorial for Beginners 1 - Getting Started and Installing Python (For Absolute Beginners)
+    Python Tutorial for Beginners 2 - Numbers and Math in Python
+    Python Tutorial for Beginners 3 - Variables and Inputs
 
 And that's basically all there is to it! The Playlist class is relatively straightforward.

--- a/pytube/__init__.py
+++ b/pytube/__init__.py
@@ -8,6 +8,8 @@ __title__ = "pytube3"
 __author__ = "Nick Ficano, Harold Martin"
 __license__ = "MIT License"
 __copyright__ = "Copyright 2019 Nick Ficano"
+__js__ = None
+__js_url__ = None
 
 from pytube.version import __version__
 from pytube.streams import Stream

--- a/pytube/__main__.py
+++ b/pytube/__main__.py
@@ -14,6 +14,7 @@ from typing import List
 from typing import Optional
 from urllib.parse import parse_qsl
 
+import pytube
 from pytube import Caption
 from pytube import CaptionQuery
 from pytube import extract
@@ -137,12 +138,6 @@ class YouTube:
                 apply_descrambler(self.vid_info, fmt)
             apply_descrambler(self.player_config_args, fmt)
 
-            if not self.js:
-                if not self.embed_html:
-                    self.embed_html = request.get(url=self.embed_url)
-                self.js_url = extract.js_url(self.embed_html)
-                self.js = request.get(self.js_url)
-
             apply_signature(self.player_config_args, fmt, self.js)
 
             # build instances of :class:`Stream <Stream>`
@@ -185,18 +180,26 @@ class YouTube:
             self.vid_info_url = extract.video_info_url_age_restricted(
                 self.video_id, self.watch_url
             )
+            self.js_url = extract.js_url(self.embed_html)
         else:
             self.vid_info_url = extract.video_info_url(
                 video_id=self.video_id, watch_url=self.watch_url
             )
+            self.js_url = extract.js_url(self.watch_html)
 
         self.initial_data_raw = extract.initial_data(self.watch_html)
         self.initial_data = json.loads(self.initial_data_raw)
 
         self.vid_info_raw = request.get(self.vid_info_url)
-        if not self.age_restricted:
-            self.js_url = extract.js_url(self.watch_html)
+
+        # If the js_url doesn't match the cached url, fetch the new js and update
+        #  the cache; otherwise, load the cache.
+        if pytube.__js_url__ != self.js_url:
             self.js = request.get(self.js_url)
+            pytube.__js__ = self.js
+            pytube.__js_url__ = self.js_url
+        else:
+            self.js = pytube.__js__
 
     def initialize_stream_objects(self, fmt: str) -> None:
         """Convert manifest data to instances of :class:`Stream <Stream>`.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -58,8 +58,8 @@ def test_video_keywords(cipher_signature):
 
 
 def test_js_caching(cipher_signature):
-    assert pytube.__js__ != None
-    assert pytube.__js_url__ != None
+    assert pytube.__js__ is not None
+    assert pytube.__js_url__ is not None
     assert pytube.__js__ == cipher_signature.js
     assert pytube.__js_url__ == cipher_signature.js_url
 


### PR DESCRIPTION
Introduces new cached variables to the library, `pytube.__js__` and `pytube.__js_url__`, in order to reduce the number of network requests made by an application. The media player javascript typically won't change during the course of an application run, so there's no reason to download the javascript for *every* video. This should speed up the code by a second or two here or there on longer runs that download multiple videos.