### PR TITLE
docs: fix simple typo, integrationn -> integration

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,7 +52,7 @@ Roadmap
 -------
 
 - Allow downloading age restricted content
-- Complete ffmpeg integrationn
+- Complete ffmpeg integration
 
 The User Guide
 --------------


### PR DESCRIPTION
There is a small typo in docs/index.rst.

Should read `integration` rather than `integrationn`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md