### PR TITLE
[Bug Fix] Change from hardcoded FPS to dynamically extract from stream data

### DIFF
--- a/pytube/extract.py
+++ b/pytube/extract.py
@@ -441,6 +441,7 @@ def apply_descrambler(stream_data: Dict, key: str) -> None:
                     "type": format_item["mimeType"],
                     "quality": format_item["quality"],
                     "itag": format_item["itag"],
+                    "fps": format_item["fps"] if 'video' in format_item["mimeType"] else None,
                     "bitrate": format_item.get("bitrate"),
                     "is_otf": (format_item.get("type") == otf_type),
                 }
@@ -462,6 +463,7 @@ def apply_descrambler(stream_data: Dict, key: str) -> None:
                     "type": format_item["mimeType"],
                     "quality": format_item["quality"],
                     "itag": format_item["itag"],
+                    "fps": format_item["fps"] if 'video' in format_item["mimeType"] else None,
                     "bitrate": format_item.get("bitrate"),
                     "is_otf": (format_item.get("type") == otf_type),
                 }

--- a/pytube/itags.py
+++ b/pytube/itags.py
@@ -117,7 +117,6 @@ ITAGS = {
 }
 
 HDR = [330, 331, 332, 333, 334, 335, 336, 337]
-_60FPS = [272, 298, 299, 302, 303, 308, 315, 398, 399, 400, 401, 402, 571] + HDR
 _3D = [82, 83, 84, 85, 100, 101, 102]
 LIVE = [91, 92, 93, 94, 95, 96, 132, 151]
 
@@ -139,7 +138,6 @@ def get_format_profile(itag: int) -> Dict:
         "is_live": itag in LIVE,
         "is_3d": itag in _3D,
         "is_hdr": itag in HDR,
-        "fps": 60 if itag in _60FPS else 30,
         "is_dash": (
             itag in DASH_AUDIO
             or itag in DASH_VIDEO

--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -75,7 +75,7 @@ class Stream:
         itag_profile = get_format_profile(self.itag)
         self.is_dash = itag_profile["is_dash"]
         self.abr = itag_profile["abr"]  # average bitrate (audio streams only)
-        self.fps = itag_profile[
+        self.fps = stream[
             "fps"
         ]  # frames per second (video streams only)
         self.resolution = itag_profile[

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -9,7 +9,7 @@ import pytest
         ({"progressive": True}, [18, 22]),
         ({"resolution": "720p"}, [22, 136, 247, 398]),
         ({"res": "720p"}, [22, 136, 247, 398]),
-        ({"fps": 30, "resolution": "480p"}, [135, 244, 397]),
+        ({"fps": 24, "resolution": "480p"}, [135, 244, 397]),
         ({"mime_type": "audio/mp4"}, [140]),
         ({"type": "audio"}, [140, 249, 250, 251]),
         ({"subtype": "3gpp"}, []),
@@ -175,6 +175,6 @@ def test_repr(cipher_signature):
         )
     ) == (
         '[<Stream: itag="18" mime_type="video/mp4" '
-        'res="360p" fps="30fps" vcodec="avc1.42001E" '
+        'res="360p" fps="24fps" vcodec="avc1.42001E" '
         'acodec="mp4a.40.2" progressive="True" type="video">]'
     )

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -285,7 +285,7 @@ def test_repr_for_audio_streams(cipher_signature):
 def test_repr_for_video_streams(cipher_signature):
     stream = str(cipher_signature.streams.filter(only_video=True)[0])
     expected = (
-        '<Stream: itag="137" mime_type="video/mp4" res="1080p" fps="30fps" '
+        '<Stream: itag="137" mime_type="video/mp4" res="1080p" fps="24fps" '
         'vcodec="avc1.640028" progressive="False" type="video">'
     )
     assert stream == expected
@@ -294,7 +294,7 @@ def test_repr_for_video_streams(cipher_signature):
 def test_repr_for_progressive_streams(cipher_signature):
     stream = str(cipher_signature.streams.filter(progressive=True)[0])
     expected = (
-        '<Stream: itag="18" mime_type="video/mp4" res="360p" fps="30fps" '
+        '<Stream: itag="18" mime_type="video/mp4" res="360p" fps="24fps" '
         'vcodec="avc1.42001E" acodec="mp4a.40.2" progressive="True" '
         'type="video">'
     )
@@ -304,7 +304,7 @@ def test_repr_for_progressive_streams(cipher_signature):
 def test_repr_for_adaptive_streams(cipher_signature):
     stream = str(cipher_signature.streams.filter(adaptive=True)[0])
     expected = (
-        '<Stream: itag="137" mime_type="video/mp4" res="1080p" fps="30fps" '
+        '<Stream: itag="137" mime_type="video/mp4" res="1080p" fps="24fps" '
         'vcodec="avc1.640028" progressive="False" type="video">'
     )
     assert stream == expected


### PR DESCRIPTION
Note: Since this is my first PR to this repository, I'll happily accept any criticism or pointers.

### Changes

As discussed in [issue #919](https://github.com/pytube/pytube/issues/919), the FPS data given by `pytube` is hardcoded  as follows:

https://github.com/pytube/pytube/blob/5340b13e80614f6c9dbcc57437c6d96165e60617/pytube/itags.py#L120
https://github.com/pytube/pytube/blob/5340b13e80614f6c9dbcc57437c6d96165e60617/pytube/itags.py#L142

where, as @tfdahlin pointed out, these values are based upon the **maximum** FPS for each itag, as discussed [here](https://gist.github.com/AgentOak/34d47c65b1d28829bb17c24c04a0096f).

This PR's main modification is to `extract.py`, where the FPS is extracted from the stream format data directly, with the appropriate change being made to `streams.py`, and the now deprecated FPS data being removed from `itags.py`.

### Tests

In some test cases, such as those using this video: https://youtube.com/watch?v=2lAe1cqCOXo, the FPS can be seen to be 24 by looking at the YouTube "stats for nerds" (by right clicking the video), however in test cases such at this it's defined as 30 FPS:

https://github.com/pytube/pytube/blob/5340b13e80614f6c9dbcc57437c6d96165e60617/tests/test_streams.py#L276-L282

I've edited all of the test cases to correctly list this video as 24 FPS, however in the future it may be worth adding additional test cases with videos of varying frames per second.