### PR TITLE
Fix : getting non-progressive streams by resolution

### DIFF
--- a/pytube/query.py
+++ b/pytube/query.py
@@ -253,8 +253,6 @@ class StreamQuery(Sequence):
     def get_by_resolution(self, resolution: str) -> Optional[Stream]:
         """Get the corresponding :class:`Stream <Stream>` for a given resolution.
 
-        Stream must be a progressive mp4.
-
         :param str resolution:
             Video resolution i.e. "720p", "480p", "360p", "240p", "144p"
         :rtype: :class:`Stream <Stream>` or None
@@ -264,7 +262,7 @@ class StreamQuery(Sequence):
 
         """
         return self.filter(
-            progressive=True, subtype="mp4", resolution=resolution
+            resolution=resolution
         ).first()
 
     def get_lowest_resolution(self) -> Optional[Stream]:
@@ -277,8 +275,7 @@ class StreamQuery(Sequence):
 
         """
         return (
-            self.filter(progressive=True, subtype="mp4")
-            .order_by("resolution")
+            self.order_by("resolution")
             .first()
         )
 
@@ -291,7 +288,7 @@ class StreamQuery(Sequence):
             not found.
 
         """
-        return self.filter(progressive=True).order_by("resolution").last()
+        return self.order_by("resolution").last()
 
     def get_audio_only(self, subtype: str = "mp4") -> Optional[Stream]:
         """Get highest bitrate audio stream for given codec (defaults to mp4)


### PR DESCRIPTION
I think users should be able to get streams with a certain resolution even if they aren't progressive mp4.
And by manually using the filter() function, they can specify which ones they want to get.

Example :
```Python
from pytube import YouTube

vid = YouTube(r"https://www.youtube.com/watch?v=qmtmse1xh_Q")

print(vid.streams.get_by_resolution("480p"))
```

Before, the output was :
> None

Now it's :
> <Stream: itag="135" mime_type="video/mp4" res="480p" fps="30fps" vcodec="avc1.4d401f" progressive="False" type="video">

***
We can manually specify what streams we want to get with the filter() function :
```Python
print(vid.streams.filter(progressive=True, subtype="mp4").get_by_resolution("480p"))
```
So we will get :
> None
