### PR TITLE
Support for quoted attributes in transform object

### DIFF
--- a/pytube/cipher.py
+++ b/pytube/cipher.py
@@ -37,8 +37,8 @@ class Cipher:
         var_match = var_regex.search(self.transform_plan[0])
         if not var_match:
             raise RegexMatchError(
-            caller="__init__", pattern="var_regex"
-        )
+                caller="__init__", pattern=var_regex.pattern
+            )
         var = var_match.group(0)[:-1]
         self.transform_map = get_transform_map(js, var)
         self.js_func_patterns = [
@@ -102,10 +102,10 @@ class Cipher:
             if parse_match:
                 fn_name, fn_arg = parse_match.groups()
                 return fn_name, int(fn_arg)
-        
+
         raise RegexMatchError(
-                caller="parse_function", pattern="js_func_regex"
-            )
+            caller="parse_function", pattern="js_func_patterns"
+        )
 
 
 def get_initial_function_name(js: str) -> str:

--- a/pytube/cipher.py
+++ b/pytube/cipher.py
@@ -33,9 +33,18 @@ logger = logging.getLogger(__name__)
 class Cipher:
     def __init__(self, js: str):
         self.transform_plan: List[str] = get_transform_plan(js)
-        var, _ = self.transform_plan[0].split(".")
+        var_regex = re.compile(r"^\w+\W")
+        var_match = var_regex.search(self.transform_plan[0])
+        if not var_match:
+            raise RegexMatchError(
+            caller="__init__", pattern="var_regex"
+        )
+        var = var_match.group(0)[:-1]
         self.transform_map = get_transform_map(js, var)
-        self.js_func_regex = re.compile(r"\w+\.(\w+)\(\w,(\d+)\)")
+        self.js_func_patterns = [
+            r"\w+\.(\w+)\(\w,(\d+)\)",
+            r"\w+\[(\"\w+\")\]\(\w,(\d+)\)"
+        ]
 
     def get_signature(self, ciphered_signature: str) -> str:
         """Decipher the signature.
@@ -87,13 +96,16 @@ class Cipher:
 
         """
         logger.debug("parsing transform function")
-        parse_match = self.js_func_regex.search(js_func)
-        if not parse_match:
-            raise RegexMatchError(
+        for pattern in self.js_func_patterns:
+            regex = re.compile(pattern)
+            parse_match = regex.search(js_func)
+            if parse_match:
+                fn_name, fn_arg = parse_match.groups()
+                return fn_name, int(fn_arg)
+        
+        raise RegexMatchError(
                 caller="parse_function", pattern="js_func_regex"
             )
-        fn_name, fn_arg = parse_match.groups()
-        return fn_name, int(fn_arg)
 
 
 def get_initial_function_name(js: str) -> str:


### PR DESCRIPTION
A few hours ago all of the sudden I couldn't download anything and systematically got hit with an error when trying to load a url:
```
Traceback (most recent call last):
  File "test.py", line 4, in <module>
    yt = YouTube(url)
  File "C:\Users\user\envs\ytgui\lib\site-packages\pytube\__main__.py", line 105, in __init__
    self.descramble()
  File "C:\Users\user\envs\ytgui\lib\site-packages\pytube\__main__.py", line 177, in descramble
    apply_signature(self.player_config_args, fmt, self.js)
  File "C:\Users\user\envs\ytgui\lib\site-packages\pytube\extract.py", line 370, in apply_signature
    cipher = Cipher(js=js)
  File "C:\Users\user\envs\ytgui\lib\site-packages\pytube\cipher.py", line 37, in __init__
    var, _ = self.transform_plan[0].split(".")
ValueError: not enough values to unpack (expected 2, got 1)
```

So I looked a bit inside cipher.py and it seems that YouTube slighlty modified its cipher syntax: some transform functions are now stored inside quoted attributes of the obfuscated variable, accessed via brackets:

```javascript
var Mx={
  FH:function(a){a.reverse()},
  "do":function(a,b){var c=a[0];a[0]=a[b%a.length];a[b%a.length]=c},
  xK:function(a,b){a.splice(0,b)}
};
```

A typical transform_plan now looks something like this, which breaks the routine to retrieve the obfuscated variable name, and the parse_function method.
```python
['Mx["do"](a,17)', 'Mx.FH(a,61)', 'Mx.xK(a,3)', 'Mx["do"](a,12)', 'Mx.xK(a,1)', 'Mx.FH(a,37)', 'Mx["do"](a,47)', 'Mx.FH(a,6)']
```

Fortunately the transform map is still built correctly, so I just replaced the routine to find the variable name with a short regex and modified the parse_function method to allow for multiple patterns, and it seems to work now !
