### PR TITLE
Fixed error because transform_plan does not use dot but bracket

### DIFF
--- a/pytube/cipher.py
+++ b/pytube/cipher.py
@@ -33,8 +33,17 @@ logger = logging.getLogger(__name__)
 class Cipher:
     def __init__(self, js: str):
         self.transform_plan: List[str] = get_transform_plan(js)
-        var, _ = self.transform_plan[0].split(".")
+
+        if "." not in self.transform_plan[0] and "[" not in self.transform_plan[0]:
+            raise RegexMatchError(
+                caller="__init__", pattern="multiple"
+            )
+        elif "." in self.transform_plan[0]:
+            var, _ = self.transform_plan[0].split(".")
+        elif "[" in self.transform_plan[0]:
+            var = self.transform_plan[0][:self.transform_plan[0].find("[")]
         self.transform_map = get_transform_map(js, var)
+
         self.js_func_regex = re.compile(r"\w+\.(\w+)\(\w,(\d+)\)")
 
     def get_signature(self, ciphered_signature: str) -> str:


### PR DESCRIPTION
The pytube.YouTube function creates a ValueError because transform_plan has a new pattern. 
Error message: `ValueError: not enough values to unpack (expected 2, got 1)`

This is because transform_plan does not always use ".", but it uses "[..]". An example of self.transform_plan includes:
`['Mx["do"](a,17)', 'Mx.FH(a,61)', ...]`

This PR checks if self.transform_plan[0] contains either "." or "[".

Thank you.

Cheers,
Minsuk