### PR TITLE
Fix for the new youtube playlist requests

### DIFF
--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -122,7 +122,8 @@ class Playlist(Sequence):
             # extra data required for post request
             {
                 "continuation": continuation,
-                "context": {"client": {"clientName": "WEB", "clientVersion": "2.20200720.00.02"}}
+                "context": {"client": {"clientName": "WEB",
+                                       "clientVersion": "2.20200720.00.02"}}
             }
         )
 
@@ -160,8 +161,9 @@ class Playlist(Sequence):
                 # this is the json tree structure, if the json was directly sent
                 # by the server in a continuation response
                 # no longer a list and no longer has the "response" key
-                important_content = initial_data['onResponseReceivedActions'][0]['appendContinuationItemsAction']
-                videos = important_content['continuationItems']
+                important_content = initial_data['onResponseReceivedActions'][0][
+                    'appendContinuationItemsAction']['continuationItems']
+                videos = important_content
             except (KeyError, IndexError, TypeError) as p:
                 print(p)
                 return [], None

--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -30,16 +30,33 @@ class Playlist(Sequence):
         if proxies:
             install_proxy(proxies)
 
-        # extracted from requests on the webpage, but can also be located in
-        # the initial html (script with ytcfg.set)
-        self.yt_api_key = "AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8"
+        # These need to be initialized as None for the properties.
+        self._html = None
+        self._ytcfg = None
 
         self.playlist_id = extract.playlist_id(url)
 
         self.playlist_url = (
             f"https://www.youtube.com/playlist?list={self.playlist_id}"
         )
-        self.html = request.get(self.playlist_url)
+
+    @property
+    def html(self):
+        if self._html:
+            return self._html
+        self._html = request.get(self.playlist_url)
+        return self._html
+
+    @property
+    def ytcfg(self):
+        if self._ytcfg:
+            return self._ytcfg
+        self._ytcfg = extract.get_ytcfg(self.html)
+        return self._ytcfg
+
+    @property
+    def yt_api_key(self):
+        return self.ytcfg['INNERTUBE_API_KEY']
 
     def _paginate(
         self, until_watch_id: Optional[str] = None

--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -122,8 +122,12 @@ class Playlist(Sequence):
             # extra data required for post request
             {
                 "continuation": continuation,
-                "context": {"client": {"clientName": "WEB",
-                                       "clientVersion": "2.20200720.00.02"}}
+                "context": {
+                    "client": {
+                        "clientName": "WEB",
+                        "clientVersion": "2.20200720.00.02"
+                    }
+                }
             }
         )
 

--- a/pytube/extract.py
+++ b/pytube/extract.py
@@ -24,6 +24,7 @@ from pytube.exceptions import RegexMatchError
 from pytube.helpers import regex_search
 from pytube.metadata import YouTubeMetadata
 from pytube.parser import parse_for_object
+from pytube.parser import parse_for_all_objects
 
 logger = logging.getLogger(__name__)
 
@@ -351,6 +352,40 @@ def get_ytplayer_config(html: str) -> Any:
 
     raise RegexMatchError(
         caller="get_ytplayer_config", pattern="config_patterns, setconfig_patterns"
+    )
+
+
+def get_ytcfg(html: str) -> str:
+    """Get the entirety of the ytcfg object.
+
+    This is built over multiple pieces, so we have to find all matches and
+    combine the dicts together.
+
+    :param str html:
+        The html contents of the watch page.
+    :rtype: str
+    :returns:
+        Substring of the html containing the encoded manifest data.
+    """
+    ytcfg = {}
+    ytcfg_patterns = [
+        r"ytcfg\s=\s",
+        r"ytcfg\.set\("
+    ]
+    for pattern in ytcfg_patterns:
+        # Try each pattern consecutively and try to build a cohesive object
+        try:
+            found_objects = parse_for_all_objects(html, pattern)
+            for obj in found_objects:
+                ytcfg.update(obj)
+        except HTMLParseError:
+            continue
+
+    if len(ytcfg) > 0:
+        return ytcfg
+
+    raise RegexMatchError(
+        caller="get_ytcfg", pattern="ytcfg_pattenrs"
     )
 
 

--- a/pytube/parser.py
+++ b/pytube/parser.py
@@ -130,6 +130,5 @@ def parse_for_object_from_startpoint(html, start_point):
     except json.decoder.JSONDecodeError:
         try:
             return ast.literal_eval(full_obj)
-        except ValueError:
-            print('Failed to parse.')
+        except (ValueError, SyntaxError):
             raise HTMLParseError('Could not parse object.')

--- a/pytube/parser.py
+++ b/pytube/parser.py
@@ -4,6 +4,39 @@ import re
 from pytube.exceptions import HTMLParseError
 
 
+def parse_for_all_objects(html, preceding_regex):
+    """Parses input html to find all matches for the input starting point.
+
+    :param str html:
+        HTML to be parsed for an object.
+    :param str preceding_regex:
+        Regex to find the string preceding the object.
+    :rtype list:
+    :returns:
+        A list of dicts created from parsing the objects.
+    """
+    result = []
+    regex = re.compile(preceding_regex)
+    match_iter = regex.finditer(html)
+    for match in match_iter:
+        if match:
+            start_index = match.end()
+            try:
+                obj = parse_for_object_from_startpoint(html, start_index)
+            except HTMLParseError:
+                # Some of the instances might fail because set is technically
+                # a method of the ytcfg object. We'll skip these since they
+                # don't seem relevant at the moment.
+                continue
+            else:
+                result.append(obj)
+
+    if len(result) == 0:
+        raise HTMLParseError(f'No matches for regex {preceding_regex}')
+
+    return result
+
+
 def parse_for_object(html, preceding_regex):
     """Parses input html to find the end of a JavaScript object.
 
@@ -20,11 +53,11 @@ def parse_for_object(html, preceding_regex):
     if not result:
         raise HTMLParseError(f'No matches for regex {preceding_regex}')
 
-    start_index = result.span()[1]
+    start_index = result.end()
     return parse_for_object_from_startpoint(html, start_index)
 
 
-def parse_for_object_from_startpoint(html, start_point):
+def find_object_from_startpoint(html, start_point):
     """Parses input html to find the end of a JavaScript object.
 
     :param str html:
@@ -77,10 +110,26 @@ def parse_for_object_from_startpoint(html, start_point):
         i += 1
 
     full_obj = html[:i]
+    return full_obj
+
+
+def parse_for_object_from_startpoint(html, start_point):
+    """JSONifies an object parsed from HTML.
+
+    :param str html:
+        HTML to be parsed for an object.
+    :param int start_point:
+        Index of where the object starts.
+    :rtype dict:
+    :returns:
+        A dict created from parsing the object.
+    """
+    full_obj = find_object_from_startpoint(html, start_point)
     try:
         return json.loads(full_obj)
     except json.decoder.JSONDecodeError:
         try:
             return ast.literal_eval(full_obj)
         except ValueError:
+            print('Failed to parse.')
             raise HTMLParseError('Could not parse object.')

--- a/pytube/parser.py
+++ b/pytube/parser.py
@@ -110,7 +110,7 @@ def find_object_from_startpoint(html, start_point):
         i += 1
 
     full_obj = html[:i]
-    return full_obj
+    return full_obj  # noqa: R504
 
 
 def parse_for_object_from_startpoint(html, start_point):

--- a/tests/contrib/test_playlist.py
+++ b/tests/contrib/test_playlist.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 from pytube import Playlist
 
 
-@mock.patch("pytube.contrib.playlist.request.get")
+@mock.patch("pytube.request.get")
 def test_title(request_get):
     request_get.return_value = (
         "<title>(149) Python Tutorial for Beginners "
@@ -24,7 +24,7 @@ def test_title(request_get):
     )
 
 
-@mock.patch("pytube.contrib.playlist.request.get")
+@mock.patch("pytube.request.get")
 def test_init_with_playlist_url(request_get):
     request_get.return_value = ""
     url = (
@@ -35,7 +35,7 @@ def test_init_with_playlist_url(request_get):
     assert playlist.playlist_url == url
 
 
-@mock.patch("pytube.contrib.playlist.request.get")
+@mock.patch("pytube.request.get")
 def test_init_with_watch_url(request_get):
     request_get.return_value = ""
     url = (
@@ -49,7 +49,7 @@ def test_init_with_watch_url(request_get):
     )
 
 
-@mock.patch("pytube.contrib.playlist.request.get")
+@mock.patch("pytube.request.get")
 def test_last_updated(request_get, playlist_html):
     expected = datetime.date(2020, 3, 11)
     request_get.return_value = playlist_html
@@ -60,13 +60,11 @@ def test_last_updated(request_get, playlist_html):
     assert playlist.last_updated == expected
 
 
-@mock.patch("pytube.contrib.playlist.request.get")
+@mock.patch("pytube.request.get")
 def test_video_urls(request_get, playlist_html):
     url = "https://www.fakeurl.com/playlist?list=whatever"
     request_get.return_value = playlist_html
     playlist = Playlist(url)
-    playlist._find_load_more_url = MagicMock(return_value=None)
-    request_get.assert_called()
     assert playlist.video_urls == [
         "https://www.youtube.com/watch?v=ujTCoH21GlA",
         "https://www.youtube.com/watch?v=45ryDIPHdGg",
@@ -81,15 +79,22 @@ def test_video_urls(request_get, playlist_html):
         "https://www.youtube.com/watch?v=g1Zbuk1gAfk",
         "https://www.youtube.com/watch?v=zixd-si9Q-o",
     ]
+    request_get.assert_called()
+
+@mock.patch("pytube.request.get")
+def test_html(request_get, playlist_html):
+    url = "https://www.fakeurl.com/playlist?list=whatever"
+    request_get.return_value = playlist_html
+    playlist = Playlist(url)
+    assert playlist.html == playlist_html
+    request_get.assert_called()
 
 
-@mock.patch("pytube.contrib.playlist.request.get")
+@mock.patch("pytube.request.get")
 def test_repr(request_get, playlist_html):
     url = "https://www.fakeurl.com/playlist?list=whatever"
     request_get.return_value = playlist_html
     playlist = Playlist(url)
-    playlist._find_load_more_url = MagicMock(return_value=None)
-    request_get.assert_called()
     assert (
         repr(playlist) == "["
         "'https://www.youtube.com/watch?v=ujTCoH21GlA', "
@@ -106,30 +111,29 @@ def test_repr(request_get, playlist_html):
         "'https://www.youtube.com/watch?v=zixd-si9Q-o'"
         "]"
     )
+    request_get.assert_called()
 
 
-@mock.patch("pytube.contrib.playlist.request.get")
+@mock.patch("pytube.request.get")
 def test_sequence(request_get, playlist_html):
     url = "https://www.fakeurl.com/playlist?list=whatever"
     request_get.return_value = playlist_html
     playlist = Playlist(url)
-    playlist._find_load_more_url = MagicMock(return_value=None)
     assert playlist[0] == "https://www.youtube.com/watch?v=ujTCoH21GlA"
     assert len(playlist) == 12
 
 
-@mock.patch("pytube.contrib.playlist.request.get")
+@mock.patch("pytube.request.get")
 @mock.patch("pytube.cli.YouTube.__init__", return_value=None)
 def test_videos(youtube, request_get, playlist_html):
     url = "https://www.fakeurl.com/playlist?list=whatever"
     request_get.return_value = playlist_html
     playlist = Playlist(url)
-    playlist._find_load_more_url = MagicMock(return_value=None)
-    request_get.assert_called()
     assert len(list(playlist.videos)) == 12
+    request_get.assert_called()
 
 
-@mock.patch("pytube.contrib.playlist.request.get")
+@mock.patch("pytube.request.get")
 @mock.patch("pytube.cli.YouTube.__init__", return_value=None)
 def test_load_more(youtube, request_get, playlist_html):
     url = "https://www.fakeurl.com/playlist?list=whatever"
@@ -138,12 +142,11 @@ def test_load_more(youtube, request_get, playlist_html):
         '{"content_html":"", "load_more_widget_html":""}',
     ]
     playlist = Playlist(url)
-    playlist._find_load_more_url = MagicMock(side_effect=["dummy", None])
-    request_get.assert_called()
     assert len(list(playlist.videos)) == 12
+    request_get.assert_called()
 
 
-@mock.patch("pytube.contrib.playlist.request.get")
+@mock.patch("pytube.request.get")
 @mock.patch("pytube.contrib.playlist.install_proxy", return_value=None)
 def test_proxy(install_proxy, request_get):
     url = "https://www.fakeurl.com/playlist?list=whatever"
@@ -152,21 +155,20 @@ def test_proxy(install_proxy, request_get):
     install_proxy.assert_called_with({"http": "things"})
 
 
-@mock.patch("pytube.contrib.playlist.request.get")
+@mock.patch("pytube.request.get")
 def test_trimmed(request_get, playlist_html):
     url = "https://www.fakeurl.com/playlist?list=whatever"
     request_get.return_value = playlist_html
     playlist = Playlist(url)
-    playlist._find_load_more_url = MagicMock(return_value=None)
-    assert request_get.call_count == 1
     trimmed = list(playlist.trimmed("1BYu65vLKdA"))
     assert trimmed == [
         "https://www.youtube.com/watch?v=ujTCoH21GlA",
         "https://www.youtube.com/watch?v=45ryDIPHdGg",
     ]
+    assert request_get.call_count == 1
 
 
-@mock.patch("pytube.contrib.playlist.request.get")
+@mock.patch("pytube.request.get")
 def test_playlist_failed_pagination(request_get, playlist_long_html):
     url = "https://www.fakeurl.com/playlist?list=whatever"
     request_get.side_effect = [
@@ -189,7 +191,7 @@ def test_playlist_failed_pagination(request_get, playlist_long_html):
     # ) # noqa
 
 
-@mock.patch("pytube.contrib.playlist.request.get")
+@mock.patch("pytube.request.get")
 def test_playlist_pagination(request_get, playlist_html, playlist_long_html):
     url = "https://www.fakeurl.com/playlist?list=whatever"
     request_get.side_effect = [
@@ -205,7 +207,7 @@ def test_playlist_pagination(request_get, playlist_html, playlist_long_html):
     assert request_get.call_count == 2
 
 
-@mock.patch("pytube.contrib.playlist.request.get")
+@mock.patch("pytube.request.get")
 def test_trimmed_pagination(request_get, playlist_html, playlist_long_html):
     url = "https://www.fakeurl.com/playlist?list=whatever"
     request_get.side_effect = [
@@ -222,7 +224,7 @@ def test_trimmed_pagination(request_get, playlist_html, playlist_long_html):
 
 
 # TODO: Test case not clear to me
-@mock.patch("pytube.contrib.playlist.request.get")
+@mock.patch("pytube.request.get")
 def test_trimmed_pagination_not_found(
     request_get, playlist_html, playlist_long_html
 ):
@@ -241,7 +243,7 @@ def test_trimmed_pagination_not_found(
 
 
 # test case for playlist with submenus
-@mock.patch("pytube.contrib.playlist.request.get")
+@mock.patch("pytube.request.get")
 def test_playlist_submenu(
         request_get, playlist_submenu_html):
     url = "https://www.fakeurl.com/playlist?list=whatever"

--- a/tests/contrib/test_playlist.py
+++ b/tests/contrib/test_playlist.py
@@ -169,16 +169,20 @@ def test_trimmed(request_get, playlist_html):
 
 
 @mock.patch("pytube.request.get")
-def test_playlist_failed_pagination(request_get, playlist_long_html):
+@mock.patch("pytube.request.post")
+def test_playlist_failed_pagination(request_post, request_get, playlist_long_html):
     url = "https://www.fakeurl.com/playlist?list=whatever"
     request_get.side_effect = [
         playlist_long_html,
-        "{}",
+    ]
+    request_post.side_effect = [
+        "{}"
     ]
     playlist = Playlist(url)
     video_urls = playlist.video_urls
     assert len(video_urls) == 100
-    assert request_get.call_count == 2
+    assert request_get.call_count == 1
+    assert request_post.call_count == 1
     # TODO: Cannot get this test to work probably
     # request_get.assert_called_with(
     #    "https://www.youtube.com/browse_ajax?ctoken" # noqa
@@ -192,10 +196,13 @@ def test_playlist_failed_pagination(request_get, playlist_long_html):
 
 
 @mock.patch("pytube.request.get")
-def test_playlist_pagination(request_get, playlist_html, playlist_long_html):
+@mock.patch("pytube.request.post")
+def test_playlist_pagination(request_post, request_get, playlist_html, playlist_long_html):
     url = "https://www.fakeurl.com/playlist?list=whatever"
     request_get.side_effect = [
-        playlist_long_html,
+        playlist_long_html
+    ]
+    request_post.side_effect = [
         '{"content_html":"<a '
         'href=\\"/watch?v=BcWz41-4cDk&amp;feature=plpp_video&amp;ved'
         '=CCYQxjQYACITCO33n5-pn-cCFUG3xAodLogN2yj6LA\\">}", '
@@ -204,7 +211,8 @@ def test_playlist_pagination(request_get, playlist_html, playlist_long_html):
     ]
     playlist = Playlist(url)
     assert len(playlist.video_urls) == 100
-    assert request_get.call_count == 2
+    assert request_get.call_count == 1
+    assert request_post.call_count == 1
 
 
 @mock.patch("pytube.request.get")

--- a/tests/contrib/test_playlist.py
+++ b/tests/contrib/test_playlist.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import datetime
 from unittest import mock
-from unittest.mock import MagicMock
 
 from pytube import Playlist
 
@@ -80,6 +79,7 @@ def test_video_urls(request_get, playlist_html):
         "https://www.youtube.com/watch?v=zixd-si9Q-o",
     ]
     request_get.assert_called()
+
 
 @mock.patch("pytube.request.get")
 def test_html(request_get, playlist_html):


### PR DESCRIPTION
Youtube changed their request and response format for playlists between 2021.03.02 and 2021.03.03.

This should also fix #949

Implements a new request function, because the new requests need to be post. This could technically be implemented into the get function, because "method" does not really influence the behaviour of urllib.request.Request, but the presence/absence of "data" does. To avoid confusion, its implemented in a new function.

Implements data and data encoding into _execute_request for the post requests.

Implemented content-type headers for the post requests, since the youtube servers are strict on content-type and if not added to the request headers this results in HTTPError [400]: Bad Request for every request.

Implemented data into the _execute_request and _build_continuation_url functions, which is required for the post requests.

Changed the format for the urls int the _build_continuation_url functions, which requires an api key. It was extracted from youtube playlist continuation requests on a browser, but it can also be found in a script on the initial playlist html, which contains "ytcfg.set". If necessary, extracting the api key from the initial html can be implemented.

Implemented a new format for the direct json responses from the youtube servers. The response is no longer a list and does not have the "response" key anymore.