### PR TITLE
Defer web requests until absolutely necessary

### DIFF
--- a/pytube/__main__.py
+++ b/pytube/__main__.py
@@ -44,7 +44,6 @@ class YouTube:
     def __init__(
         self,
         url: str,
-        defer_prefetch_init: bool = False,
         on_progress_callback: Optional[Callable[[Any, bytes, int], None]] = None,
         on_complete_callback: Optional[Callable[[Any, Optional[str]], None]] = None,
         proxies: Dict[str, str] = None,

--- a/pytube/__main__.py
+++ b/pytube/__main__.py
@@ -100,6 +100,10 @@ class YouTube:
         if proxies:
             install_proxy(proxies)
 
+        self._author = None
+        self._title = None
+        self._publish_date = None
+
     @property
     def watch_html(self):
         if self._watch_html:
@@ -284,6 +288,10 @@ class YouTube:
 
     @property
     def vid_info(self):
+        """Parse the raw vid info and return the parsed result.
+
+        :rtype: Dict[Any, Any]
+        """
         return dict(parse_qsl(self.vid_info_raw))
 
     @property
@@ -321,7 +329,6 @@ class YouTube:
         """Get the thumbnail url image.
 
         :rtype: str
-
         """
         thumbnail_details = (
             self.player_response.get("videoDetails", {})
@@ -339,25 +346,38 @@ class YouTube:
         """Get the publish date.
 
         :rtype: datetime
-
         """
-        return extract.publish_date(self.watch_html)
+        if self._publish_date:
+            return self._publish_date
+        self._publish_date = extract.publish_date(self.watch_html)
+        return self._publish_date
+
+    @publish_date.setter
+    def publish_date(self, value):
+        """Sets the publish date."""
+        self._publish_date = value
 
     @property
     def title(self) -> str:
         """Get the video title.
 
         :rtype: str
-
         """
-        return self.player_response['videoDetails']['title']
+        if self._title:
+            return self._title
+        self._title = self.player_response['videoDetails']['title']
+        return self._title
+
+    @title.setter
+    def title(self, value):
+        """Sets the title value."""
+        self._title = value
 
     @property
     def description(self) -> str:
         """Get the video description.
 
         :rtype: str
-
         """
         return self.player_response.get("videoDetails", {}).get("shortDescription")
 
@@ -375,7 +395,6 @@ class YouTube:
         """Get the video length in seconds.
 
         :rtype: int
-
         """
         return int(
             self.player_config_args.get("length_seconds")
@@ -391,7 +410,6 @@ class YouTube:
         """Get the number of the times the video has been viewed.
 
         :rtype: int
-
         """
         return int(
             self.player_response.get("videoDetails", {}).get("viewCount")
@@ -402,9 +420,17 @@ class YouTube:
         """Get the video author.
         :rtype: str
         """
-        return self.player_response.get("videoDetails", {}).get(
+        if self._author:
+            return self._author
+        self._author = self.player_response.get("videoDetails", {}).get(
             "author", "unknown"
         )
+        return self._author
+
+    @author.setter
+    def author(self, value):
+        """Set the video author."""
+        self._author = value
 
     @property
     def keywords(self) -> List[str]:

--- a/pytube/__main__.py
+++ b/pytube/__main__.py
@@ -180,7 +180,7 @@ class YouTube:
             return self._initial_data
         self._initial_data = extract.initial_data(self.watch_html)
         return self._initial_data
-    
+
     def check_availability(self):
         """Check whether the video is available.
 
@@ -289,7 +289,7 @@ class YouTube:
     @property
     def vid_info(self):
         return dict(parse_qsl(self.vid_info_raw))
-    
+
     @property
     def caption_tracks(self) -> List[Caption]:
         """Get a list of :class:`Caption <Caption>`.

--- a/pytube/helpers.py
+++ b/pytube/helpers.py
@@ -173,6 +173,14 @@ def install_proxy(proxy_handler: Dict[str, str]) -> None:
 
 
 def uniqueify(duped_list: List) -> List:
+    """Remove duplicate items from a list, while maintaining list order.
+
+    :param List duped_list
+        List to remove duplicates from
+
+    :return List result
+        De-duplicated list
+    """
     seen: Dict[Any, bool] = {}
     result = []
     for item in duped_list:

--- a/pytube/helpers.py
+++ b/pytube/helpers.py
@@ -209,7 +209,6 @@ def create_mock_html_json(vid_id) -> Dict[str, Any]:
         'https://www.youtube.com/watch?v=%s' % vid_id,
         defer_prefetch_init=True
     )
-    yt.prefetch()
     html_data = {
         'url': yt.watch_url,
         'js': yt.js,

--- a/pytube/helpers.py
+++ b/pytube/helpers.py
@@ -213,10 +213,7 @@ def create_mock_html_json(vid_id) -> Dict[str, Any]:
     pytube_mocks_path = os.path.join(pytube_dir_path, 'tests', 'mocks')
     gzip_filepath = os.path.join(pytube_mocks_path, gzip_filename)
 
-    yt = YouTube(
-        'https://www.youtube.com/watch?v=%s' % vid_id,
-        defer_prefetch_init=True
-    )
+    yt = YouTube(f'https://www.youtube.com/watch?v={vid_id}')
     html_data = {
         'url': yt.watch_url,
         'js': yt.js,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,18 @@ def load_and_init_from_playback_file(filename, mock_urlopen):
     ]
     mock_urlopen.return_value = mock_url_open_object
 
-    return YouTube(pb["url"])
+    # Pytest caches this result, so we can speed up the tests
+    #  by causing the object to fetch all the relevant information
+    #  it needs. Previously, this was handled by prefetch_init()
+    #  and descramble(), but this functionality has since been
+    #  deferred
+    v = YouTube(pb["url"])
+    v.watch_html
+    v.vid_info_raw
+    v.js
+    v.fmt_streams
+    v.player_response
+    return v
 
 
 @pytest.fixture

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -79,7 +79,7 @@ def test_raises_video_private(private):
         ]
         mock_url_open.return_value = mock_url_open_object
         with pytest.raises(VideoPrivate):
-            YouTube('https://youtube.com/watch?v=m8uHb5jIGN8')
+            YouTube('https://youtube.com/watch?v=m8uHb5jIGN8').streams
 
 
 def test_raises_recording_unavailable(missing_recording):
@@ -91,7 +91,7 @@ def test_raises_recording_unavailable(missing_recording):
         ]
         mock_url_open.return_value = mock_url_open_object
         with pytest.raises(RecordingUnavailable):
-            YouTube('https://youtube.com/watch?v=5YceQ8YqYMc')
+            YouTube('https://youtube.com/watch?v=5YceQ8YqYMc').streams
 
 
 def test_raises_video_region_blocked(region_blocked):
@@ -103,4 +103,4 @@ def test_raises_video_region_blocked(region_blocked):
         ]
         mock_url_open.return_value = mock_url_open_object
         with pytest.raises(VideoRegionBlocked):
-            YouTube('https://youtube.com/watch?v=hZpzr8TbF08')
+            YouTube('https://youtube.com/watch?v=hZpzr8TbF08').streams

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -117,14 +117,16 @@ def test_create_mock_html_json(mock_url_open, mock_open):
     mock_url_open_object = mock.Mock()
 
     # Order is:
-    # 1. watch_html -- must have js match
-    # 2. vid_info_raw
-    # 3. js
+    # 1. watch_html -- must have jsurl match
+    # 2. embed html
+    # 3. watch html
+    # 4. raw vid info
     mock_url_open_object.read.side_effect = [
         (b'yt.setConfig({"PLAYER_CONFIG":{"args":[]}});ytInitialData = {};ytInitialPlayerResponse = {};'  # noqa: E501
          b'"jsUrl":"/s/player/13371337/player_ias.vflset/en_US/base.js"'),
+        b'embed_html',
+        b'watch_html',
         b'vid_info_raw',
-        b'js_result',
     ]
     mock_url_open.return_value = mock_url_open_object
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -34,7 +34,7 @@ def test_video_unavailable(get):
         "https://www.youtube.com/watch?v=9bZkp7q19f0", defer_prefetch_init=True
     )
     with pytest.raises(RegexMatchError):
-        youtube.prefetch()
+        youtube.check_availability()
 
 
 def test_video_keywords(cipher_signature):
@@ -62,17 +62,3 @@ def test_js_caching(cipher_signature):
     assert pytube.__js_url__ is not None
     assert pytube.__js__ == cipher_signature.js
     assert pytube.__js_url__ == cipher_signature.js_url
-
-    with mock.patch('pytube.request.urlopen') as mock_urlopen:
-        mock_urlopen_object = mock.Mock()
-
-        # We should never read the js from this
-        mock_urlopen_object.read.side_effect = [
-            cipher_signature.watch_html.encode('utf-8'),
-            cipher_signature.vid_info_raw.encode('utf-8'),
-            cipher_signature.js.encode('utf-8')
-        ]
-
-        mock_urlopen.return_value = mock_urlopen_object
-        cipher_signature.prefetch()
-        assert mock_urlopen.call_count == 2

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -21,7 +21,6 @@ def test_install_proxy(opener):
     proxies = {"http": "http://www.example.com:3128/"}
     YouTube(
         "https://www.youtube.com/watch?v=9bZkp7q19f0",
-        defer_prefetch_init=True,
         proxies=proxies,
     )
     opener.assert_called()
@@ -30,9 +29,7 @@ def test_install_proxy(opener):
 @mock.patch("pytube.request.get")
 def test_video_unavailable(get):
     get.return_value = ""
-    youtube = YouTube(
-        "https://www.youtube.com/watch?v=9bZkp7q19f0", defer_prefetch_init=True
-    )
+    youtube = YouTube("https://www.youtube.com/watch?v=9bZkp7q19f0")
     with pytest.raises(RegexMatchError):
         youtube.check_availability()
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,7 +5,7 @@ import pytest
 
 import pytube
 from pytube import YouTube
-from pytube.exceptions import VideoUnavailable
+from pytube.exceptions import RegexMatchError
 
 
 @mock.patch("pytube.__main__.YouTube")
@@ -29,11 +29,11 @@ def test_install_proxy(opener):
 
 @mock.patch("pytube.request.get")
 def test_video_unavailable(get):
-    get.return_value = None
+    get.return_value = ""
     youtube = YouTube(
         "https://www.youtube.com/watch?v=9bZkp7q19f0", defer_prefetch_init=True
     )
-    with pytest.raises(VideoUnavailable):
+    with pytest.raises(RegexMatchError):
         youtube.prefetch()
 
 

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -251,17 +251,17 @@ def test_on_complete_hook(cipher_signature):
 
 def test_author(cipher_signature):
     expected = "Test author"
-    cipher_signature.player_response = {"videoDetails": {"author": expected}}
+    cipher_signature._player_response = {"videoDetails": {"author": expected}}
     assert cipher_signature.author == expected
 
     expected = "unknown"
-    cipher_signature.player_response = {}
+    cipher_signature._player_response = {'key': 'value'}
     assert cipher_signature.author == expected
 
 
 def test_thumbnail_when_in_details(cipher_signature):
     expected = "some url"
-    cipher_signature.player_response = {
+    cipher_signature._player_response = {
         "videoDetails": {"thumbnail": {"thumbnails": [{"url": expected}]}}
     }
     assert cipher_signature.thumbnail_url == expected
@@ -269,7 +269,7 @@ def test_thumbnail_when_in_details(cipher_signature):
 
 def test_thumbnail_when_not_in_details(cipher_signature):
     expected = "https://img.youtube.com/vi/2lAe1cqCOXo/maxresdefault.jpg"
-    cipher_signature.player_response = {}
+    cipher_signature._player_response = {'key': 'value'}
     assert cipher_signature.thumbnail_url == expected
 
 

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -255,6 +255,7 @@ def test_author(cipher_signature):
     assert cipher_signature.author == expected
 
     expected = "unknown"
+    cipher_signature.author = None
     cipher_signature._player_response = {'key': 'value'}
     assert cipher_signature.author == expected
 


### PR DESCRIPTION
This defers a lot of the network requests until they're absolutely necessary. For example, there's no real reason to fetch the embed_html or js file if the user is only trying to get the title, which should be available from watch_html. Additionally, this will pave the way for pre-filling some aspects of a YouTube object for operations on non-video elements, like playlists and channels. Currently, if a user tries to iterate over `Playlist.videos` and comes across a video that is not accessible, an uncatchable exception will be thrown, because it is being thrown in a generator. By deferring this kind of thing until later, the user will be able to catch these issues inside of a loop, rather than needing to create a loop calling next(). Additionally, this will allows us to set certain attributes of a YouTube object without needing to make any web requests at all sometimes. For example, playlists should be able to access the video title without needing to make a request to every single video page to do so.

When merged, this closes #951 