### PR TITLE
Fix #957 KeyError when 'dur' not present in XML subtitles

### DIFF
--- a/pytube/captions.py
+++ b/pytube/captions.py
@@ -67,11 +67,12 @@ class Caption:
         segments = []
         root = ElementTree.fromstring(xml_captions)
         for i, child in enumerate(list(root)):
-            if "dur" not in child.attrib:
-                continue
             text = child.text or ""
             caption = unescape(text.replace("\n", " ").replace("  ", " "),)
-            duration = float(child.attrib["dur"])
+            try:
+                duration = float(child.attrib["dur"])
+            except KeyError:
+                duration = 0.0
             start = float(child.attrib["start"])
             end = start + duration
             sequence_number = i + 1  # convert from 0-indexed to 1.

--- a/pytube/captions.py
+++ b/pytube/captions.py
@@ -67,6 +67,8 @@ class Caption:
         segments = []
         root = ElementTree.fromstring(xml_captions)
         for i, child in enumerate(list(root)):
+            if "dur" not in child.attrib:
+                continue
             text = child.text or ""
             caption = unescape(text.replace("\n", " ").replace("  ", " "),)
             duration = float(child.attrib["dur"])


### PR DESCRIPTION
I have fixed the KeyError when 'dur' not present in XML subtitles by simply skipping the subtitles with no duration in the subtutle loop in xml_caption_to_srt() method