### PR TITLE
Link corresponding website to all badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   </p>
   <p align="center">
 	<a href="https://pypi.org/project/pytube/"><img src="https://img.shields.io/pypi/dm/pytube?style=flat-square" alt="pypi"/></a>
-    <img src="https://readthedocs.org/projects/python-pytube/badge/?version=latest&style=flat-square" />
+	<a href="https://python-pytube.readthedocs.io/en/latest/"><img src="https://readthedocs.org/projects/python-pytube/badge/?version=latest&style=flat-square" /></a>
     <a href="https://codecov.io/gh/pytube/pytube" aria-label="coverage"><img src="https://img.shields.io/codecov/c/github/pytube/pytube?style=flat-square" /></a>
 	<a href="https://pypi.org/project/pytube/"><img src="https://img.shields.io/pypi/v/pytube?style=flat-square" /></a>
   </p>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
     <img src="https://assets.nickficano.com/gh-pytube.min.svg" width="456" height="143" alt="pytube logo" />
   </p>
   <p align="center">
-    <img src="https://img.shields.io/pypi/dm/pytube?style=flat-square" alt="pypi"/>
+	<a href="https://pypi.org/project/pytube/"><img src="https://img.shields.io/pypi/dm/pytube?style=flat-square" alt="pypi"/></a>
     <img src="https://readthedocs.org/projects/python-pytube/badge/?version=latest&style=flat-square" />
     <a href="https://codecov.io/gh/pytube/pytube" aria-label="coverage"><img src="https://img.shields.io/codecov/c/github/pytube/pytube?style=flat-square" /></a>
 	<a href="https://pypi.org/project/pytube/"><img src="https://img.shields.io/pypi/v/pytube?style=flat-square" /></a>

--- a/README.md
+++ b/README.md
@@ -12,25 +12,25 @@
   </p>
 </div>
 
-
-
 ### Actively soliciting contributers!
+
 Have ideas for how pytube can be improved? Feel free to open an issue or a pull
 request!
 
 # pytube
+
 *pytube* is a very serious, lightweight, dependency-free Python library (and
 command-line utility) for downloading YouTube Videos.
 
-
 ## Documentation
+
 Detailed documentation about how to use the library can be found on our
 [readthedocs](https://python-pytube.readthedocs.io) page. This is recommended
 for most use cases. If you just want to quickly download a single video,
 the [quickstart](#Quickstart) guide below might be what you're looking for.
 
-
 ## Description
+
 YouTube is the most popular video-sharing platform in the world and as a hacker
 you may encounter a situation where you want to script something to download
 videos. For this I present to you *pytube*.
@@ -44,8 +44,8 @@ for different download events, such as  ``on progress`` or ``on complete``.
 Finally *pytube* also includes a command-line utility, allowing you to quickly
 download videos right from terminal.
 
-
 ## Features
+
 - Support for both progressive & DASH streams
 - Support for downloading complete playlist
 - Easily register ``on_download_progress`` & ``on_download_complete`` callbacks
@@ -57,11 +57,13 @@ download videos right from terminal.
 - No third-party dependencies
 
 ## Quickstart
+
 This guide is only meant to cover the most basic usage of the library. For more
 detailed information, please refer to our
 [readthedocs](https://python-pytube.readthedocs.io) page.
 
 ### Installation
+
 Pytube requires an installation of python 3.6 or greater, as well as pip.
 Pip is typically bundled with python installations, and you can find options
 for how to install python at https://python.org.
@@ -80,6 +82,7 @@ $ python -m pip install git+https://github.com/pytube/pytube
 ```
 
 ### Using pytube in a python script
+
 To download a video using the library in a script, you'll need to first import
 the YouTube class from the library, and pass it an argument of the video url.
 From there, you can access the streams and download them.
@@ -97,6 +100,7 @@ From there, you can access the streams and download them.
 ```
 
 ### Using the command-line interface
+
 Using the CLI is extremely straightforward as well. To download a video at the
 highest progressive quality, you can use the following command:
 ```bash

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
     <img src="https://img.shields.io/pypi/dm/pytube?style=flat-square" alt="pypi"/>
     <img src="https://readthedocs.org/projects/python-pytube/badge/?version=latest&style=flat-square" />
     <a href="https://codecov.io/gh/pytube/pytube" aria-label="coverage"><img src="https://img.shields.io/codecov/c/github/pytube/pytube?style=flat-square" /></a>
-    <img src="https://img.shields.io/pypi/v/pytube?style=flat-square" />
+	<a href="https://pypi.org/project/pytube/"><img src="https://img.shields.io/pypi/v/pytube?style=flat-square" /></a>
   </p>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <p>
-    <img src="https://assets.nickficano.com/gh-pytube.min.svg" width="456" height="143" alt="pytube logo" />
+    <a href="#"><img src="https://assets.nickficano.com/gh-pytube.min.svg" width="456" height="143" alt="pytube logo" /></a>
   </p>
   <p align="center">
 	<a href="https://pypi.org/project/pytube/"><img src="https://img.shields.io/pypi/dm/pytube?style=flat-square" alt="pypi"/></a>

--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@
   <p align="center">
     <img src="https://img.shields.io/pypi/dm/pytube?style=flat-square" alt="pypi"/>
     <img src="https://readthedocs.org/projects/python-pytube/badge/?version=latest&style=flat-square" />
-    <a href="https://codecov.io/gh/pytube/pytube" aria-label="coverage">
-      <img src="https://img.shields.io/codecov/c/github/pytube/pytube?style=flat-square" />
-    </a>
+    <a href="https://codecov.io/gh/pytube/pytube" aria-label="coverage"><img src="https://img.shields.io/codecov/c/github/pytube/pytube?style=flat-square" /></a>
     <img src="https://img.shields.io/pypi/v/pytube?style=flat-square" />
   </p>
 </div>


### PR DESCRIPTION
This patch does the following.

- Organize markdown headers for readability
- Link all badges to it's reasonable website