### PR TITLE
Enhancement/timeout

### DIFF
--- a/pytube/exceptions.py
+++ b/pytube/exceptions.py
@@ -13,6 +13,10 @@ class PytubeError(Exception):
     """
 
 
+class MaxRetriesExceeded(PytubeError):
+    """Maximum number of retries exceeded."""
+
+
 class HTMLParseError(PytubeError):
     """HTML could not be parsed"""
 

--- a/pytube/request.py
+++ b/pytube/request.py
@@ -52,11 +52,7 @@ def get(url, extra_headers=None, timeout=socket._GLOBAL_DEFAULT_TIMEOUT):
     """
     if extra_headers is None:
         extra_headers = {}
-    response = _execute_request(
-        url,
-        headers=extra_headers,
-        timeout=timeout
-    )
+    response = _execute_request(url, headers=extra_headers, timeout=timeout)
     return response.read().decode("utf-8")
 
 

--- a/pytube/request.py
+++ b/pytube/request.py
@@ -33,12 +33,7 @@ def _execute_request(
         if not isinstance(data, bytes):
             data = bytes(json.dumps(data), encoding="utf-8")
     if url.lower().startswith("http"):
-        request = Request(
-            url,
-            headers=base_headers,
-            method=method,
-            data=data
-        )
+        request = Request(url, headers=base_headers, method=method, data=data)
     else:
         raise ValueError("Invalid URL")
     return urlopen(request, timeout=timeout)  # nosec

--- a/pytube/request.py
+++ b/pytube/request.py
@@ -172,12 +172,13 @@ def stream(
                     timeout=timeout
                 )
             except URLError as e:
-                if isinstance(e, socket.timeout):
+                if isinstance(e.reason, socket.timeout):
                     pass
             else:
                 # On a successful request, break from loop
                 break
             tries += 1
+
         if file_size == default_range_size:
             try:
                 content_range = response.info()["Content-Range"]

--- a/pytube/request.py
+++ b/pytube/request.py
@@ -10,7 +10,7 @@ from urllib.error import URLError
 from urllib.request import Request
 from urllib.request import urlopen
 
-from pytube.exceptions import RegexMatchError
+from pytube.exceptions import RegexMatchError, MaxRetriesExceeded
 from pytube.helpers import regex_search
 
 logger = logging.getLogger(__name__)

--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -234,7 +234,7 @@ class Stream:
             (optional) Skip existing files, defaults to True
         :type skip_existing: bool
         :param timeout:
-            (optional) Request timeout length
+            (optional) Request timeout length in seconds
         :type timeout: int
         :returns:
             Path to the saved video

--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -211,7 +211,8 @@ class Stream:
         filename: Optional[str] = None,
         filename_prefix: Optional[str] = None,
         skip_existing: bool = True,
-        timeout: Optional[int] = None
+        timeout: Optional[int] = None,
+        max_retries: Optional[int] = 0
     ) -> str:
         """Write the media stream to disk.
 
@@ -248,20 +249,20 @@ class Stream:
         )
 
         if skip_existing and self.exists_at_path(file_path):
-            logger.debug("file %s already exists, skipping", file_path)
+            logger.debug(f'file {file_path} already exists, skipping')
             self.on_complete(file_path)
             return file_path
 
         bytes_remaining = self.filesize
-        logger.debug(
-            "downloading (%s total bytes) file to %s",
-            self.filesize,
-            file_path,
-        )
+        logger.debug(f'downloading ({self.filesize} total bytes) file to {file_path}')
 
         with open(file_path, "wb") as fh:
             try:
-                for chunk in request.stream(self.url):
+                for chunk in request.stream(
+                    self.url,
+                    timeout=timeout,
+                    max_retries=max_retries
+                ):
                     # reduce the (bytes) remainder by the length of the chunk.
                     bytes_remaining -= len(chunk)
                     # send to the on_progress callback.
@@ -270,7 +271,11 @@ class Stream:
                 if e.code != 404:
                     raise
                 # Some adaptive streams need to be requested with sequence numbers
-                for chunk in request.seq_stream(self.url):
+                for chunk in request.seq_stream(
+                    self.url,
+                    timeout=timeout,
+                    max_retries=max_retries
+                ):
                     # reduce the (bytes) remainder by the length of the chunk.
                     bytes_remaining -= len(chunk)
                     # send to the on_progress callback.

--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -211,6 +211,7 @@ class Stream:
         filename: Optional[str] = None,
         filename_prefix: Optional[str] = None,
         skip_existing: bool = True,
+        timeout: Optional[int] = None
     ) -> str:
         """Write the media stream to disk.
 
@@ -230,8 +231,11 @@ class Stream:
             filename but still add a prefix.
         :type filename_prefix: str or None
         :param skip_existing:
-            (optional) skip existing files, defaults to True
+            (optional) Skip existing files, defaults to True
         :type skip_existing: bool
+        :param timeout:
+            (optional) Request timeout length
+        :type timeout: int
         :returns:
             Path to the saved video
         :rtype: str

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
+import socket
 import os
 from unittest import mock
+from urllib.error import URLError
 
 import pytest
 
 from pytube import request
+from pytube.exceptions import MaxRetriesExceeded
 
 
 @mock.patch("pytube.request.urlopen")
@@ -16,15 +19,24 @@ def test_streaming(mock_urlopen):
         os.urandom(8 * 1024),
         None,
     ]
-    response = mock.Mock()
-    response.read.side_effect = fake_stream_binary
-    response.info.return_value = {"Content-Range": "bytes 200-1000/24576"}
-    mock_urlopen.return_value = response
+    mock_response = mock.Mock()
+    mock_response.read.side_effect = fake_stream_binary
+    mock_response.info.return_value = {"Content-Range": "bytes 200-1000/24576"}
+    mock_urlopen.return_value = mock_response
     # When
-    response = request.stream("http://fakeassurl.gov")
+    response = request.stream("http://fakeassurl.gov/streaming_test")
     # Then
-    call_count = len(list(response))
-    assert call_count == 3
+    assert len(b''.join(response)) == 3 * 8 * 1024
+    assert mock_response.read.call_count == 4
+
+
+@mock.patch('pytube.request.urlopen')
+def test_timeout(mock_urlopen):
+    exc = URLError(reason=socket.timeout('timed_out'))
+    mock_urlopen.side_effect = exc
+    with pytest.raises(MaxRetriesExceeded):
+        gen = request.stream('http://fakeassurl.gov/timeout_test', timeout=1)
+        next(gen)
 
 
 @mock.patch("pytube.request.urlopen")

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -34,9 +34,9 @@ def test_streaming(mock_urlopen):
 def test_timeout(mock_urlopen):
     exc = URLError(reason=socket.timeout('timed_out'))
     mock_urlopen.side_effect = exc
+    generator = request.stream('http://fakeassurl.gov/timeout_test', timeout=1)
     with pytest.raises(MaxRetriesExceeded):
-        gen = request.stream('http://fakeassurl.gov/timeout_test', timeout=1)
-        next(gen)
+        next(generator)
 
 
 @mock.patch("pytube.request.urlopen")


### PR DESCRIPTION
Adds optional request timeout and max retry arguments to `streams.download()`. If a network connection gets closed for unforseen reasons, pytube may get stuck attempting to download something it is unable to download. This allows users to set a timeout and retry policy for such downloads.

Closes #947 