### PR TITLE
Raise non-timeout URLErrors correctly

### DIFF
--- a/pytube/request.py
+++ b/pytube/request.py
@@ -161,8 +161,12 @@ def stream(
                     timeout=timeout
                 )
             except URLError as e:
+                # We only want to skip over timeout errors, and
+                # raise any other URLError exceptions
                 if isinstance(e.reason, socket.timeout):
                     pass
+                else:
+                    raise
             else:
                 # On a successful request, break from loop
                 break


### PR DESCRIPTION
I forgot to raise non-timeout URLErrors when I added the exception handling here