### PR TITLE
Remove the chunk size file write limit to speed up downloads.

### DIFF
--- a/pytube/request.py
+++ b/pytube/request.py
@@ -12,7 +12,6 @@ from pytube.exceptions import RegexMatchError, MaxRetriesExceeded
 from pytube.helpers import regex_search
 
 logger = logging.getLogger(__name__)
-default_chunk_size = 4096  # 4kb
 default_range_size = 9437184  # 9MB
 
 
@@ -179,7 +178,7 @@ def stream(
             except (KeyError, IndexError, ValueError) as e:
                 logger.error(e)
         while True:
-            chunk = response.read(default_chunk_size)
+            chunk = response.read()
             if not chunk:
                 break
             downloaded += len(chunk)


### PR DESCRIPTION
I'm not sure what prompted the decision, but a long time ago, the amount of a file that was written to disk at a time was set to 4kb, while the size of a chunk of video to get downloaded was set to 9MB. This means that for every 9MB of file downloaded, somewhere around 2300 write operations are made to disk, which appears to significantly slow the download