### PR TITLE
Improve metadata availability

### DIFF
--- a/pytube/__main__.py
+++ b/pytube/__main__.py
@@ -423,6 +423,20 @@ class YouTube:
         return self.player_response.get('videoDetails', {}).get('keywords', [])
 
     @property
+    def channel_id(self) -> str:
+        """Get the video poster's channel id.
+        :rtype: str
+        """
+        return self.player_response.get('videoDetails', {}).get('channelId', None)
+
+    @property
+    def channel_url(self) -> str:
+        """Construct the channel url for the video's poster from the channel id.
+        :rtype: str
+        """
+        return f'https://www.youtube.com/channel/{self.channel_id}'
+
+    @property
     def metadata(self) -> Optional[YouTubeMetadata]:
         """Get the metadata for the video.
 

--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -377,7 +377,6 @@ class Playlist(Sequence):
         """
         return f'https://www.youtube.com/channel/{self.owner_id}'
 
-
     @staticmethod
     def _video_url(watch_path: str):
         return f"https://www.youtube.com{watch_path}"

--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -328,7 +328,7 @@ class Playlist(Sequence):
         :rtype: int
         """
         count_text = self.sidebar_info[0]['playlistSidebarPrimaryInfoRenderer'][
-            'stats'][0]['runs'][0]
+            'stats'][0]['runs'][0]['text']
         return int(count_text)
 
     @property

--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -1,13 +1,12 @@
 """Module to download a complete playlist from a youtube channel."""
 import json
 import logging
-import re
 from collections.abc import Sequence
 from datetime import date, datetime
 from typing import Dict, Iterable, List, Optional, Tuple, Union
 
 from pytube import extract, request, YouTube
-from pytube.helpers import cache, DeferredGeneratorList, install_proxy, regex_search, uniqueify
+from pytube.helpers import cache, DeferredGeneratorList, install_proxy, uniqueify
 
 logger = logging.getLogger(__name__)
 
@@ -296,7 +295,7 @@ class Playlist(Sequence):
         :rtype: datetime.date
         """
         last_updated_text = self.sidebar_info[0]['playlistSidebarPrimaryInfoRenderer'][
-        'stats'][2]['runs'][1]['text']
+            'stats'][2]['runs'][1]['text']
         date_components = last_updated_text.split()
         month = date_components[0]
         day = date_components[1].strip(',')
@@ -314,12 +313,12 @@ class Playlist(Sequence):
         :rtype: Optional[str]
         """
         return self.sidebar_info[0]['playlistSidebarPrimaryInfoRenderer'][
-        'title']['runs'][0]['text']
+            'title']['runs'][0]['text']
 
     @property
     def description(self) -> str:
         return self.sidebar_info[0]['playlistSidebarPrimaryInfoRenderer'][
-        'description']['simpleText']
+            'description']['simpleText']
 
     @property
     def length(self):
@@ -329,7 +328,7 @@ class Playlist(Sequence):
         :rtype: int
         """
         return int(self.sidebar_info[0]['playlistSidebarPrimaryInfoRenderer'][
-        'stats'][0]['runs'][0])
+            'stats'][0]['runs'][0])
 
     @property
     def views(self):
@@ -340,7 +339,7 @@ class Playlist(Sequence):
         """
         # "1,234,567 views"
         views_text = self.sidebar_info[0]['playlistSidebarPrimaryInfoRenderer'][
-        'stats'][1]['simpleText']
+            'stats'][1]['simpleText']
         # "1,234,567"
         count_text = views_text.split()[0]
         # "1234567"
@@ -355,7 +354,7 @@ class Playlist(Sequence):
         :rtype: str
         """
         return self.sidebar_info[1]['playlistSidebarSecondaryInfoRenderer'][
-        'videoOwner']['title']['runs'][0]['text']
+            'videoOwner']['title']['runs'][0]['text']
 
     @staticmethod
     def _video_url(watch_path: str):

--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -355,7 +355,28 @@ class Playlist(Sequence):
         :rtype: str
         """
         return self.sidebar_info[1]['playlistSidebarSecondaryInfoRenderer'][
-            'videoOwner']['title']['runs'][0]['text']
+            'videoOwner']['videoOwnerRenderer']['title']['runs'][0]['text']
+
+    @property
+    def owner_id(self):
+        """Extract the channel_id of the owner of the playlist.
+
+        :return: Playlist owner's channel ID.
+        :rtype: str
+        """
+        return self.sidebar_info[1]['playlistSidebarSecondaryInfoRenderer'][
+            'videoOwner']['videoOwnerRenderer']['title']['runs'][0][
+            'navigationEndpoint']['browseEndpoint']['browseId']
+
+    @property
+    def owner_url(self):
+        """Create the channel url of the owner of the playlist.
+
+        :return: Playlist owner's channel url.
+        :rtype: str
+        """
+        return f'https://www.youtube.com/channel/{self.owner_id}'
+
 
     @staticmethod
     def _video_url(watch_path: str):

--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -327,8 +327,9 @@ class Playlist(Sequence):
         :return: Playlist video count
         :rtype: int
         """
-        return int(self.sidebar_info[0]['playlistSidebarPrimaryInfoRenderer'][
-            'stats'][0]['runs'][0])
+        count_text = self.sidebar_info[0]['playlistSidebarPrimaryInfoRenderer'][
+            'stats'][0]['runs'][0]
+        return int(count_text)
 
     @property
     def views(self):

--- a/tests/contrib/test_playlist.py
+++ b/tests/contrib/test_playlist.py
@@ -5,11 +5,8 @@ from pytube import Playlist
 
 
 @mock.patch("pytube.request.get")
-def test_title(request_get):
-    request_get.return_value = (
-        "<title>(149) Python Tutorial for Beginners "
-        "(For Absolute Beginners) - YouTube</title>"
-    )
+def test_title(request_get, playlist_long_html):
+    request_get.return_value = playlist_long_html
     url = (
         "https://www.fakeurl.com/playlist?list=PLS1QulWo1RIaJECMeUT4LFwJ"
         "-ghgoSH6n"
@@ -18,7 +15,7 @@ def test_title(request_get):
     pl_title = pl.title
     assert (
         pl_title
-        == "(149) Python Tutorial for Beginners (For Absolute Beginners)"
+        == "Python Tutorial for Beginners (For Absolute Beginners)"
     )
 
 
@@ -48,9 +45,9 @@ def test_init_with_watch_url(request_get):
 
 
 @mock.patch("pytube.request.get")
-def test_last_updated(request_get, playlist_html):
-    expected = datetime.date(2020, 3, 11)
-    request_get.return_value = playlist_html
+def test_last_updated(request_get, playlist_long_html):
+    expected = datetime.date(2020, 10, 8)
+    request_get.return_value = playlist_long_html
     playlist = Playlist(
         "https://www.youtube.com/playlist?list"
         "=PLS1QulWo1RIaJECMeUT4LFwJ-ghgoSH6n"

--- a/tests/contrib/test_playlist.py
+++ b/tests/contrib/test_playlist.py
@@ -248,8 +248,7 @@ def test_trimmed_pagination_not_found(
 
 # test case for playlist with submenus
 @mock.patch("pytube.request.get")
-def test_playlist_submenu(
-        request_get, playlist_submenu_html):
+def test_playlist_submenu(request_get, playlist_submenu_html):
     url = "https://www.fakeurl.com/playlist?list=whatever"
     request_get.side_effect = [
         playlist_submenu_html,
@@ -261,3 +260,63 @@ def test_playlist_submenu(
     ]
     playlist = Playlist(url)
     assert len(playlist.video_urls) == 12
+
+
+@mock.patch("pytube.request.get")
+def test_playlist_length(request_get, playlist_long_html):
+    url = 'https://www.example.com/playlist?list=whatever'
+    request_get.return_value = playlist_long_html
+    p = Playlist(url)
+    assert p.length == 217
+
+
+@mock.patch("pytube.request.get")
+def test_playlist_description(request_get, playlist_long_html):
+    url = 'https://www.example.com/playlist?list=whatever'
+    request_get.return_value = playlist_long_html
+    p = Playlist(url)
+    assert p.description == (
+        'Python Object Oriented - Learning Python in '
+        'simple and easy steps ,python,xml,script,install, A beginner\'s '
+        'tutorial containing complete knowledge of Python Syntax Object '
+        'Oriented Language, Methods, Tuples,Learn,Python,Tutorial,Interactive,'
+        'Free, Tools/Utilities,Getting the most popular pages from your Apache'
+        ' logfile,Make your life easier with Virtualenvwrapper,This site now '
+        'runs on Django,PythonForBeginners.com has a new owner,How to use '
+        'Pillow, a fork of PIL,How to use the Python Imaging Library,Python '
+        'Websites and Tutorials,How to use Envoy,Using Feedparser in Python,'
+        'Subprocess and Shell Commands in Python, Exceptions Handling, '
+        'Sockets, GUI, Extentions, XML Programming'
+    )
+
+
+@mock.patch("pytube.request.get")
+def test_playlist_views(request_get, playlist_long_html):
+    url = 'https://www.example.com/playlist?list=whatever'
+    request_get.return_value = playlist_long_html
+    p = Playlist(url)
+    assert p.views == 4617130
+
+
+@mock.patch("pytube.request.get")
+def test_playlist_owner(request_get, playlist_long_html):
+    url = 'https://www.example.com/playlist?list=whatever'
+    request_get.return_value = playlist_long_html
+    p = Playlist(url)
+    assert p.owner == 'ProgrammingKnowledge'
+
+
+@mock.patch("pytube.request.get")
+def test_playlist_owner_id(request_get, playlist_long_html):
+    url = 'https://www.example.com/playlist?list=whatever'
+    request_get.return_value = playlist_long_html
+    p = Playlist(url)
+    assert p.owner_id == 'UCs6nmQViDpUw0nuIx9c_WvA'
+
+
+@mock.patch("pytube.request.get")
+def test_playlist_owner_url(request_get, playlist_long_html):
+    url = 'https://www.example.com/playlist?list=whatever'
+    request_get.return_value = playlist_long_html
+    p = Playlist(url)
+    assert p.owner_url == 'https://www.youtube.com/channel/UCs6nmQViDpUw0nuIx9c_WvA'

--- a/tests/contrib/test_playlist.py
+++ b/tests/contrib/test_playlist.py
@@ -277,7 +277,7 @@ def test_playlist_description(request_get, playlist_long_html):
     p = Playlist(url)
     assert p.description == (
         'Python Object Oriented - Learning Python in '
-        'simple and easy steps ,python,xml,script,install, A beginner\'s '
+        "simple and easy steps ,python,xml,script,install, A beginner's "
         'tutorial containing complete knowledge of Python Syntax Object '
         'Oriented Language, Methods, Tuples,Learn,Python,Tutorial,Interactive,'
         'Free, Tools/Utilities,Getting the most popular pages from your Apache'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -57,4 +57,4 @@ def test_channel_id(cipher_signature):
 
 
 def test_channel_url(cipher_signature):
-    assert cipher_signature.channel_url == 'https://www.youtube.com/channel/UCBR8-60-B28hp2BmDPdntcQ'
+    assert cipher_signature.channel_url == 'https://www.youtube.com/channel/UCBR8-60-B28hp2BmDPdntcQ'  # noqa:E501

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -50,3 +50,11 @@ def test_js_caching(cipher_signature):
     assert pytube.__js_url__ is not None
     assert pytube.__js__ == cipher_signature.js
     assert pytube.__js_url__ == cipher_signature.js_url
+
+
+def test_channel_id(cipher_signature):
+    assert cipher_signature.channel_id == 'UCBR8-60-B28hp2BmDPdntcQ'
+
+
+def test_channel_url(cipher_signature):
+    assert cipher_signature.channel_url == 'https://www.youtube.com/channel/UCBR8-60-B28hp2BmDPdntcQ'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,14 +7,6 @@ from pytube import YouTube
 from pytube.exceptions import RegexMatchError
 
 
-@mock.patch("pytube.__main__.YouTube")
-def test_prefetch_deferred(youtube):
-    instance = youtube.return_value
-    instance.prefetch_descramble.return_value = None
-    YouTube("https://www.youtube.com/watch?v=9bZkp7q19f0", True)
-    assert not instance.prefetch_descramble.called
-
-
 @mock.patch("urllib.request.install_opener")
 def test_install_proxy(opener):
     proxies = {"http": "http://www.example.com:3128/"}


### PR DESCRIPTION
I misinterpreted #964 as wanting to create channel objects, which was already under development, when the user wanted to extract the channel url from a video. This adds that functionality.

Additionally, this should cover the request in #984 for more playlist metadata when it is complete.