### PR TITLE
Bug/vid info 404

### DIFF
--- a/pytube/__main__.py
+++ b/pytube/__main__.py
@@ -56,6 +56,7 @@ class YouTube:
         self._vid_info_url: Optional[str] = None
         self._vid_info_raw: Optional[str] = None  # content fetched by vid_info_url
         self._vid_info: Optional[Dict] = None  # parsed content of vid_info_raw
+        self._api_json: Optional[Dict] = None
 
         self._watch_html: Optional[str] = None  # the html of /watch?v=<video_id>
         self._embed_html: Optional[str] = None
@@ -107,6 +108,13 @@ class YouTube:
             return self._vid_info_raw
         self._vid_info_raw = request.get(self.vid_info_url)
         return self._vid_info_raw
+
+    @property
+    def api_json(self):
+        if self._api_json:
+            return self._api_json
+        self._api_json = request.call_api('POST', 'player', self.video_id, query_params={'videoId': self.video_id})
+        return self._api_json
 
     @property
     def age_restricted(self):

--- a/pytube/__main__.py
+++ b/pytube/__main__.py
@@ -72,7 +72,7 @@ class YouTube:
         # video_id part of /watch?v=<video_id>
         self.video_id = extract.video_id(url)
 
-        self.watch_url = f"https://youtube.com/watch?v={self.video_id}"
+        self.watch_url = f"https://www.youtube.com/watch?v={self.video_id}"
         self.embed_url = f"https://www.youtube.com/embed/{self.video_id}"
 
         # Shared between all instances of `Stream` (Borg pattern).

--- a/pytube/__main__.py
+++ b/pytube/__main__.py
@@ -193,16 +193,21 @@ class YouTube:
             return self._player_config_args
 
         self._player_config_args = self.vid_info
+        self._player_config_args = {
+            'player_response': self.vid_info
+        }
+        return self._player_config_args
+        # Skip this now?
         # On pre-signed videos, we need to use get_ytplayer_config to fix
         #  the player_response item
-        if 'streamingData' not in self.player_config_args['player_response']:
-            config_response = extract.get_ytplayer_config(self.watch_html)
-            if 'args' in config_response:
-                self.player_config_args['player_response'] = config_response['args']['player_response']  # noqa: E501
-            else:
-                self.player_config_args['player_response'] = config_response
-
-        return self._player_config_args
+        #if 'streamingData' not in self.player_config_args['player_response']:
+        #    config_response = extract.get_ytplayer_config(self.watch_html)
+        #    if 'args' in config_response:
+        #        self.player_config_args['player_response'] = config_response['args']['player_response']  # noqa: E501
+        #    else:
+        #        self.player_config_args['player_response'] = config_response
+        #
+        #return self._player_config_args
 
     @property
     def fmt_streams(self):
@@ -223,6 +228,7 @@ class YouTube:
 
         # unscramble the progressive and adaptive stream manifests.
         for fmt in stream_maps:
+            #print(self.vid_info)
             if not self.age_restricted and fmt in self.vid_info:
                 extract.apply_descrambler(self.vid_info, fmt)
             extract.apply_descrambler(self.player_config_args, fmt)
@@ -283,7 +289,8 @@ class YouTube:
 
         :rtype: Dict[Any, Any]
         """
-        return dict(parse_qsl(self.vid_info_raw))
+        return self.api_json
+        #return dict(parse_qsl(self.vid_info_raw))
 
     @property
     def caption_tracks(self) -> List[pytube.Caption]:

--- a/pytube/extract.py
+++ b/pytube/extract.py
@@ -500,6 +500,7 @@ def apply_descrambler(stream_data: Dict, key: str) -> None:
                     "fps": format_item["fps"] if 'video' in format_item["mimeType"] else None,
                     "bitrate": format_item.get("bitrate"),
                     "is_otf": (format_item.get("type") == otf_type),
+                    "content_length": format_item["contentLength"],
                 }
                 for format_item in formats
             ]
@@ -522,6 +523,7 @@ def apply_descrambler(stream_data: Dict, key: str) -> None:
                     "fps": format_item["fps"] if 'video' in format_item["mimeType"] else None,
                     "bitrate": format_item.get("bitrate"),
                     "is_otf": (format_item.get("type") == otf_type),
+                    "content_length": format_item["contentLength"],
                 }
                 for i, format_item in enumerate(formats)
             ]

--- a/pytube/extract.py
+++ b/pytube/extract.py
@@ -480,6 +480,7 @@ def apply_descrambler(stream_data: Dict, key: str) -> None:
     if key == "url_encoded_fmt_stream_map" and not stream_data.get(
         "url_encoded_fmt_stream_map"
     ):
+        streaming_data = stream_data
         if isinstance(stream_data["player_response"], str):
             streaming_data = json.loads(stream_data["player_response"])["streamingData"]
         else:

--- a/pytube/request.py
+++ b/pytube/request.py
@@ -264,3 +264,27 @@ def head(url):
     """
     response_headers = _execute_request(url, method="HEAD").info()
     return {k.lower(): v for k, v in response_headers.items()}
+
+
+def call_api(method, endpoint, video_id, query_params={}, data={}, timeout=None):
+    query_params.update(
+        {
+            'key': 'AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8',
+
+        }
+    )
+    data.update({
+        'context': {
+            'client': {
+                'clientName': 'WEB',
+                'clientVersion': '2.20200720.00.02'
+            }
+        }
+    })
+    base_url = 'https://www.youtube.com/youtubei/v1'
+    endpoint_url = f'{base_url}/{endpoint}'
+    if query_params:
+        endpoint_url = f'{endpoint_url}?{parse.urlencode(query_params)}'
+    response = _execute_request(endpoint_url, method, headers={'Content-Type': 'application/json'}, data=data)
+    json_data = json.loads(response.read())
+    return json_data

--- a/pytube/request.py
+++ b/pytube/request.py
@@ -5,7 +5,7 @@ import re
 import socket
 from functools import lru_cache
 from urllib import parse
-from urllib.error import URLError
+from urllib.error import URLError, HTTPError
 from urllib.request import Request, urlopen
 
 from pytube.exceptions import RegexMatchError, MaxRetriesExceeded
@@ -33,7 +33,12 @@ def _execute_request(
         request = Request(url, headers=base_headers, method=method, data=data)
     else:
         raise ValueError("Invalid URL")
-    return urlopen(request, timeout=timeout)  # nosec
+    try:
+        return urlopen(request, timeout=timeout)  # nosec
+    except HTTPError:
+        logger.warn(f'Exception encountered while executing web request:')
+        logger.warn(f'{method or "GET"} {url}')
+        raise
 
 
 def get(url, extra_headers=None, timeout=socket._GLOBAL_DEFAULT_TIMEOUT):

--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -62,7 +62,7 @@ class Stream:
         self.is_otf: bool = stream["is_otf"]
         self.bitrate: Optional[int] = stream["bitrate"]
 
-        self._filesize: Optional[int] = None  # filesize in bytes
+        self._filesize: int = stream["content_length"]  # filesize in bytes
 
         # Additional information about the stream format, such as resolution,
         # frame rate, and whether the stream is live (HLS) or 3D.
@@ -147,13 +147,13 @@ class Stream:
         :returns:
             Filesize (in bytes) of the stream.
         """
-        if self._filesize is None:
-            try:
-                self._filesize = request.filesize(self.url)
-            except HTTPError as e:
-                if e.code != 404:
-                    raise
-                self._filesize = request.seq_filesize(self.url)
+        #if self._filesize is None:
+        #    try:
+        #        self._filesize = request.filesize(self.url)
+        #    except HTTPError as e:
+        #        if e.code != 404:
+        #            raise
+        #        self._filesize = request.seq_filesize(self.url)
         return self._filesize
 
     @property


### PR DESCRIPTION
This bypasses the `get_video_info` url to fix a 404 issue.

Currently in-progress, I'm getting 403 errors when attempting to access `.filesize`.
Additionally cannot process age-restricted videos right now, which I will need to find another workaround for I believe.

Closes #990