### PR TITLE
Added fix for playlist length string not parsing correctly.

### DIFF
--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -329,6 +329,7 @@ class Playlist(Sequence):
         """
         count_text = self.sidebar_info[0]['playlistSidebarPrimaryInfoRenderer'][
             'stats'][0]['runs'][0]['text']
+        count_text = count_text.replace(',','')
         return int(count_text)
 
     @property


### PR DESCRIPTION
Playlist lengths longer than 999 have commas, and these weren't being parsed correctly. This removes commas from the string, then casts to an int.