### PR TITLE
fixed regex to reenable downloading from yt

### DIFF
--- a/pytube/cipher.py
+++ b/pytube/cipher.py
@@ -265,7 +265,7 @@ def get_throttling_function_name(js: str) -> str:
         # https://github.com/ytdl-org/youtube-dl/issues/29326#issuecomment-865985377
         # a.C&&(b=a.get("n"))&&(b=Dea(b),a.set("n",b))}};
         # In above case, `Dea` is the relevant function name
-        r'a\.C&&\(b=a\.get\("n"\)\)&&\(b=([^(]+)\(b\),a\.set\("n",b\)\)}};',
+        r'a\.D&&\(b=a\.get\("n"\)\)&&\(b=([^(]+)\(b\),a\.set\("n",b\)\)}};',
     ]
     logger.debug('Finding throttling function name')
     for pattern in function_patterns:


### PR DESCRIPTION
recent changes to the YT frontend code prevented pytube from finding the proper throttling_function_name, thus downloads were failing.