### PR TITLE
Add average video quality and optional args to get desired video types

### DIFF
--- a/pytube/query.py
+++ b/pytube/query.py
@@ -261,10 +261,10 @@ class StreamQuery(Sequence):
             progressive=True, subtype="mp4", resolution=resolution
         ).first()
 
-    def get_lowest_resolution(self, video_subtype: str = "mp4") -> Optional[Stream]:
+    def get_lowest_resolution(self, subtype: str = "mp4") -> Optional[Stream]:
         """Get lowest resolution stream that is a progressive video.
 
-        :param str video_subtype:
+        :param str subtype:
             Video subtype i.e. "mp4", "3gp", "webm". (Defaults to mp4)
         :rtype: :class:`Stream <Stream>` or None
         :returns:
@@ -272,16 +272,16 @@ class StreamQuery(Sequence):
             not found.
 
         """
-        if (video_subtype == ""):
+        if (subtype == ""):
             return self.filter(progressive=True).order_by("resolution").first()
         
-        return self.filter(progressive=True, subtype=video_subtype).order_by("resolution").first()
+        return self.filter(progressive=True, subtype=subtype).order_by("resolution").first()
         
 
-    def get_highest_resolution(self, video_subtype: str = "mp4") -> Optional[Stream]:
+    def get_highest_resolution(self, subtype: str = "mp4") -> Optional[Stream]:
         """Get highest resolution stream that is a progressive video.
 
-        :param str video_subtype:
+        :param str subtype:
             Video subtype i.e. "mp4", "3gp", "webm". (Defaults to mp4)
         :rtype: :class:`Stream <Stream>` or None
         :returns:
@@ -289,26 +289,26 @@ class StreamQuery(Sequence):
             not found.
 
         """
-        if (video_subtype == ""):
+        if (subtype == ""):
             return self.filter(progressive=True).order_by("resolution").last()
 
-        return self.filter(progressive=True, subtype=video_subtype).order_by("resolution").last()
+        return self.filter(progressive=True, subtype=subtype).order_by("resolution").last()
 
-    def get_average_resolution(self,  video_subtype: str = "mp4") -> Optional[Stream]:
+    def get_average_resolution(self,  subtype: str = "mp4") -> Optional[Stream]:
         """Get average resolution stream that is a progressive video.
 
-        :param str video_subtype:
+        :param str subtype:
             Video subtype i.e. "mp4", "3gp", "webm". (Defaults to mp4)
         :rtype: :class:`Stream <Stream>` or None
         :returns:
             The :class:`Stream <Stream>` matching the given itag or None if
             not found.
         """
-        progressive_streams = self.filter(progressive=True) if (video_subtype == "") else self.filter(progressive=True, subtype=video_subtype)
+        progressive_streams = self.filter(progressive=True) if (subtype == "") else self.filter(progressive=True, subtype=subtype)
         
         return progressive_streams.order_by("resolution").middle()
 
-    def get_audio_only(self, subtype: str = video_subtype) -> Optional[Stream]:
+    def get_audio_only(self, subtype: str = "mp4") -> Optional[Stream]:
         """Get highest bitrate audio stream for given codec (defaults to mp4)
 
         :param str subtype:


### PR DESCRIPTION
Added methods to get the average of a video (`get_average_resolution()` and `middle()` to replace long array method to find middle point), and added an optional argument to `get_highest_resolution()` and `get_lowest_resolution()` called `subtype` ("mp4" by default) so it'll return any video format type with the lowest quality (".mp4", ".3gp", ".webm", etc) if it's called with `subtype= ""` as argument, but it'll not affect previous versions because the default is still "mp4".

An example of this:

```
### Old method to get video quality
print("Best quality: ", streams_video_audio.get_highest_resolution().resolution)
print("Worst quality: ", streams_video_audio.get_lowest_resolution().resolution)
print("Average quality: ", streams_video_audio[round((len(streams_video_audio) - 1) / 2)].resolution)

### Ouput
# Best quality:  720p 
# Worst quality:  360p    <--- This is wrong, this video worst quality is 144p but is .3gp not .mp4.
# Average quality:  360p
```

The resolution returned from `get_lowest_resolution()` is 360p even if the stream lowest resolution is 144p, so with this new methods, the code will be like this:

```
### New method get video quality
print("Best quality: ", streams_video_audio.get_highest_resolution(subtype="").resolution)
print("Worst quality: ", streams_video_audio.get_lowest_resolution(subtype="").resolution)
print("Average quality: ", streams_video_audio.get_average_resolution(subtype="").resolution)

### Ouput
# Best quality:  720p 
# Worst quality:  144p 
# Average quality:  360p
```