### PR TITLE
Fix GitHub Actions workflow to test with intended python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,10 @@ jobs:
           python-version: ${{ matrix.python }}
 
       - name: Upgrade pip
-        run: pip install --upgrade pipenv
+        run: pip install --upgrade pip pipenv
+
+      - name: Install pipenv
+        run: pipenv install --dev --skip-lock --python ${{ matrix.python }}
 
       - name: Run make ci
         run: make ci


### PR DESCRIPTION
Resolves #1115 

A new step was added to the workflow to setup `pipenv` with the `${{ matrix.python }}` parameter - syncing the expected python version from GitHub and actual tested version with `pipenv`/`pytest`.