### PR TITLE
Added possibility filter by part of codecname

### DIFF
--- a/pytube/query.py
+++ b/pytube/query.py
@@ -141,10 +141,10 @@ class StreamQuery(Sequence):
             filters.append(lambda s: s.abr == (abr or bitrate))
 
         if video_codec:
-            filters.append(lambda s: s.video_codec == video_codec)
+            filters.append(lambda s: s.video_codec.startswith(video_codec))
 
         if audio_codec:
-            filters.append(lambda s: s.audio_codec == audio_codec)
+            filters.append(lambda s: s.audio_codec.startswith(audio_codec))
 
         if only_audio:
             filters.append(


### PR DESCRIPTION
after changes became possible filter audio and video by part of codecname
Example:
with filter(video_codec='avc1') we can find videos with codecs like "avc1.4d401e" or "avc1.64001F"