### PR TITLE
The regex doesn't always match in the function

### DIFF
--- a/pytube/parser.py
+++ b/pytube/parser.py
@@ -155,6 +155,8 @@ def throttling_array_split(js_array):
         if curr_substring.startswith('function'):
             # Handle functions separately. These can contain commas
             match = func_regex.search(curr_substring)
+            if match is None:
+                break
             match_start, match_end = match.span()
 
             function_text = find_object_from_startpoint(curr_substring, match.span()[1])


### PR DESCRIPTION
This will break out of the while loop when we have one that doesn't match the function regex.

This youtube video was dying here because the substring didn't not match the regex. This resolves the issue for me, but not sure if it is the 100% correct solution.

This was the value of curr_substring when it died:
function(){for(var d=64,e=[];++d-e.length-32;){switch(d){case 58:d-=14;case 91:case 92:case 93:continue;case 123:d=47;case 94:case 95:case 96:continue;case 46:d=95}e.push(String.fromCharCode(d))}return e},"6EQCM",464217080,-2001785842,878812847]

That didn't match the regex and then match is None and the function dies.