### PR TITLE
Fix for parsing throttling array function

### DIFF
--- a/pytube/parser.py
+++ b/pytube/parser.py
@@ -149,7 +149,7 @@ def throttling_array_split(js_array):
     curr_substring = js_array[1:]
 
     comma_regex = re.compile(r",")
-    func_regex = re.compile(r"function\([^)]+\)")
+    func_regex = re.compile(r"function\([^)]*\)")
 
     while len(curr_substring) > 0:
         if curr_substring.startswith('function'):


### PR DESCRIPTION
As I already mentioned in #1163, it seems that YouTube has added functions without parameters, e.g.:
```js
function(){for(var d=64,e=[];++d-e.length-32;){switch(d){case 58:d-=14;case 91:case 92:case 93:continue;case 123:d=47;case 94:case 95:case 96:continue;case 46:d=95}e.push(String.fromCharCode(d))}return e}
```

So in my opinion the best fix would be to allow the regex to accept these too. That is, change the regex `function\([^)]+\)` to `function\([^)]*\)`. The `*` allows the function to have no parameters.