### PR TITLE
Fixed RegexMatchError

### DIFF
--- a/pytube/cipher.py
+++ b/pytube/cipher.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 class Cipher:
     def __init__(self, js: str):
         self.transform_plan: List[str] = get_transform_plan(js)
-        var_regex = re.compile(r"^\w+\W")
+        var_regex = re.compile(r"^\$*\w+\W")
         var_match = var_regex.search(self.transform_plan[0])
         if not var_match:
             raise RegexMatchError(


### PR DESCRIPTION
Fixed `pytube.exceptions.RegexMatchError: __init__: could not find match for ^\w+\W`

Solution proposed by [juanchosaravia](https://github.com/juanchosaravia) here
https://github.com/pytube/pytube/issues/1199#issuecomment-1016783092
