### PR TITLE
Fix @pytube/pytube #1222 #1225 #1222

### DIFF
--- a/pytube/cipher.py
+++ b/pytube/cipher.py
@@ -265,7 +265,8 @@ def get_throttling_function_name(js: str) -> str:
         # https://github.com/ytdl-org/youtube-dl/issues/29326#issuecomment-865985377
         # a.C&&(b=a.get("n"))&&(b=Dea(b),a.set("n",b))}};
         # In above case, `Dea` is the relevant function name
-        r'a\.[A-Z]&&\(b=a\.get\("n"\)\)&&\(b=([^(]+)\(b\)',
+        # r'a\.[A-Z]&&\(b=a\.get\("n"\)\)&&\(b=([^(]+)\(b\)', // Old one
+        r'([A-Za-z]{3})=function\(a\){var b=a\.split\(""\)\,'
     ]
     logger.debug('Finding throttling function name')
     for pattern in function_patterns:

--- a/pytube/parser.py
+++ b/pytube/parser.py
@@ -149,7 +149,7 @@ def throttling_array_split(js_array):
     curr_substring = js_array[1:]
 
     comma_regex = re.compile(r",")
-    func_regex = re.compile(r"function\([^)]*\)")
+    func_regex = re.compile(r"function\(.*?\)")
 
     while len(curr_substring) > 0:
         if curr_substring.startswith('function'):


### PR DESCRIPTION
Fix #1222 #1225 #1222.
The issue is on the regex of the `func_regex` of `parser.throttling_array_split()` and on the regex `function_patterns[0]` of `cipher.get_throttling_function_name()`.
Successfully tested, now in production on my app.  