### PR TITLE
Fixed to be able to use pytube with Pythonista.

### DIFF
--- a/pytube/innertube.py
+++ b/pytube/innertube.py
@@ -69,7 +69,7 @@ _default_clients = {
     }
 }
 _token_timeout = 1800
-_cache_dir = pathlib.Path(__file__).parent.resolve() / '__cache__'
+_cache_dir = str(pathlib.Path(__file__).parent.resolve() / '__cache__')
 _token_file = os.path.join(_cache_dir, 'tokens.json')
 
 


### PR DESCRIPTION
Hello, I am cpyberry.
If you happen to have a free moment, I'd be very glad if you could give me your opinion.

## Caused problem

I found that an iOS application named Pythonista cannot import pytube.
An Error was not triggered in Windows environment, but it is triggered when running in Pythonista.

```
Traceback (most recent call last):
  File "/private/var/mobile/Containers/Shared/AppGroup/id/Pythonista3/Documents/pytube/testcode.py", line 1, in <module>
    import pytube
  File "/private/var/mobile/Containers/Shared/AppGroup/id/Pythonista3/Documents/pytube/pytube/__init__.py", line 16, in <module>
    from pytube.__main__ import YouTube
  File "/private/var/mobile/Containers/Shared/AppGroup/id/Pythonista3/Documents/pytube/pytube/__main__.py", line 17, in <module>
    from pytube.innertube import InnerTube
  File "/private/var/mobile/Containers/Shared/AppGroup/id/Pythonista3/Documents/pytube/pytube/innertube.py", line 73, in <module>
    _token_file = os.path.join(_cache_dir, 'tokens.json')
  File "/var/containers/Bundle/Application/id/Pythonista3.app/Frameworks/Py3Kit.framework/pylib/posixpath.py", line 79, in join
    a = os.fspath(a)
TypeError: expected str, bytes or os.PathLike object, not PosixPath
```

The location of the cause is the following two lines.

```python
_cache_dir = pathlib.Path(__file__).parent.resolve() / '__cache__'
_token_file = os.path.join(_cache_dir, 'tokens.json')
```

I came up with the idea that converting `_cache_dir` to str type would solve this problem.

`_cache_dir = str(pathlib.Path(__file__).parent.resolve() / '__cache__')`

## Test Run
I have confirmed that the code below works in the following environments.

* Windows
** python 3.6.2
** python 3.6.10
** python 3.8.3
** python 3.9.2
* Pythonista3 v3.3

```python
import pytube

youtube_url = "youtube url"
youtube = pytube.YouTube(youtube_url)
youtube.streams.first().download()
```