### PR TITLE
Fix for RegexMatchError

### DIFF
--- a/pytube/cipher.py
+++ b/pytube/cipher.py
@@ -270,7 +270,7 @@ def get_throttling_function_name(js: str) -> str:
         # Bpa.length || iha("")) }};
         # In the above case, `iha` is the relevant function name
         r'a\.[a-zA-Z]\s*&&\s*\([a-z]\s*=\s*a\.get\("n"\)\)\s*&&\s*'
-        r'\([a-z]\s*=\s*([a-zA-Z0-9$]{3})(\[\d+\])?\([a-z]\)',
+        r'\([a-z]\s*=\s*([a-zA-Z0-9$]{2,3})(\[\d+\])?\([a-z]\)'
     ]
     logger.debug('Finding throttling function name')
     for pattern in function_patterns:
@@ -285,7 +285,7 @@ def get_throttling_function_name(js: str) -> str:
                 idx = idx.strip("[]")
                 array = re.search(
                     r'var {nfunc}\s*=\s*(\[.+?\]);'.format(
-                        nfunc=function_match.group(1)),
+                        nfunc=re.escape(function_match.group(1))),
                     js
                 )
                 if array:


### PR DESCRIPTION
Fix for 
pytube.exceptions.RegexMatchError: get_throttling_function_name: could not find match for multiple

Possible fixes: #1299 #1296 #1287