### PR TITLE
check_availability() wil check age restriction

### DIFF
--- a/pytube/__main__.py
+++ b/pytube/__main__.py
@@ -226,6 +226,8 @@ class YouTube:
                     'Please sign in to verify that you may see it.'
                 ):
                     raise exceptions.VideoPrivate(video_id=self.video_id)
+                elif reason == 'Sign in to confirm your age' and self.use_oauth == False:
+                    raise exceptions.AgeRestrictedError(video_id=self.video_id)
             elif status == 'ERROR':
                 if reason == 'Video unavailable':
                     raise exceptions.VideoUnavailable(video_id=self.video_id)


### PR DESCRIPTION
YouTube's check_availability() function should return an AgeRestrictionError if use_oauth is not turned on. This extra check will flag the video as unavailable in that case. 