### PR TITLE
mod regex to fix downloading videos

### DIFF
--- a/pytube/cipher.py
+++ b/pytube/cipher.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 class Cipher:
     def __init__(self, js: str):
         self.transform_plan: List[str] = get_transform_plan(js)
-        var_regex = re.compile(r"^\w+\W")
+        var_regex = re.compile(r"^\$*\w+\W")
         var_match = var_regex.search(self.transform_plan[0])
         if not var_match:
             raise RegexMatchError(


### PR DESCRIPTION
Pytube won't download videos until the regex in `cipher.py` (the one on line 30) is set to `r"^\$*\w+\W"`.

This according to the StackOverflow answer [here](https://stackoverflow.com/questions/70776558/pytube-exceptions-regexmatcherror-init-could-not-find-match-for-w-w)

Doing the mod on my local version of the module fixed the download.