### PR TITLE
Fix content-length #1258, #912, #160

### DIFF
--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -151,7 +151,7 @@ class Stream:
             except Exception as e:
                 if "content-length" in str(e):
                     self._filesize = int((self._monostate.duration * self.bitrate) / 8)
-                else: print(e)
+                else: raise(e)
         return self._filesize
 
     @property

--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -148,6 +148,10 @@ class Stream:
                 if e.code != 404:
                     raise
                 self._filesize = request.seq_filesize(self.url)
+            except Exception as e:
+                if "content-length" in str(e):
+                    self._filesize = int((self._monostate.duration * self.bitrate) / 8)
+                else: print(e)
         return self._filesize
 
     @property


### PR DESCRIPTION
Content-length error is caused by YouTube not sending content-length when a head request is made asking for media headers before download, 
content-length is used to get download size to be displayed in progress bar and progress hooks so it won't affect our download if it's incorrect, in this case using approximated size is fine. (better than nothing)
 
Possible fix of  #1258, #912, #160

Some of the issues was closed without a solution

mp4 & without audio streams only have the error

Here's some links to test:

https://youtu.be/xrXsm5YgiiI      #all streams except streams with audio
https://youtu.be/UQ5_ehVI7mg  #itag 160
https://youtu.be/6PDxyCLaTeU  #itag 160 and sometimes 360p&1080p
https://youtu.be/qT4a73ctcmw #itag 160