### PR TITLE
Fixed unsupported reelShelfRenderer (YT Shorts) issue (#1270) and video view count parsing

### DIFF
--- a/pytube/contrib/search.py
+++ b/pytube/contrib/search.py
@@ -76,6 +76,47 @@ class Search:
         else:
             raise IndexError
 
+    @staticmethod
+    def append_video(vid_renderer, vid_metadata, videos=None):
+        if videos is None:
+            videos = []
+        # Livestreams have "runs", non-livestreams have "simpleText",
+        #  and scheduled releases do not have 'viewCountText'
+        if 'viewCountText' in vid_renderer:
+            if 'runs' in vid_renderer['viewCountText']:
+                vid_view_count_text = vid_renderer['viewCountText']['runs'][0]['text']
+            else:
+                vid_view_count_text = vid_renderer['viewCountText']['simpleText']
+            # Strip ' views' text, then remove commas
+            stripped_text = vid_view_count_text.split()[0].replace(',', '')
+            if stripped_text == 'No':
+                vid_view_count = 0
+            else:
+                # K and M for 10^3 and 10^6
+                multiplier = 1
+                if stripped_text.endswith('K'):
+                    multiplier = 1000
+                    stripped_text = stripped_text[:-1]
+                elif stripped_text.endswith('M'):
+                    multiplier = 1000000
+                    stripped_text = stripped_text[:-1]
+                vid_view_count = int(float(stripped_text) * multiplier)
+        else:
+            vid_view_count = 0
+        if 'lengthText' in vid_renderer:
+            vid_length = vid_renderer['lengthText']['simpleText']
+        else:
+            vid_length = None
+
+        vid_metadata['view_count'] = vid_view_count
+        vid_metadata['length'] = vid_length
+
+        # Construct YouTube object from metadata and append to results
+        vid = YouTube(vid_metadata['url'])
+        vid.author = vid_metadata['channel_name']
+        vid.title = vid_metadata['title']
+        videos.append(vid)
+
     def fetch_and_parse(self, continuation=None):
         """Fetch from the innertube API and parse the results.
 
@@ -149,7 +190,9 @@ class Search:
                 if 'backgroundPromoRenderer' in video_details:
                     continue
 
-                if 'videoRenderer' not in video_details:
+                # Check if found renderer is unsupported
+                supported_renderers = {'videoRenderer', 'reelShelfRenderer'}
+                if video_details.keys().isdisjoint(supported_renderers):
                     logger.warn('Unexpected renderer encountered.')
                     logger.warn(f'Renderer name: {video_details.keys()}')
                     logger.warn(f'Search term: {self.query}')
@@ -163,48 +206,48 @@ class Search:
                 # Extract relevant video information from the details.
                 # Some of this can be used to pre-populate attributes of the
                 #  YouTube object.
-                vid_renderer = video_details['videoRenderer']
-                vid_id = vid_renderer['videoId']
-                vid_url = f'https://www.youtube.com/watch?v={vid_id}'
-                vid_title = vid_renderer['title']['runs'][0]['text']
-                vid_channel_name = vid_renderer['ownerText']['runs'][0]['text']
-                vid_channel_uri = vid_renderer['ownerText']['runs'][0][
-                    'navigationEndpoint']['commandMetadata']['webCommandMetadata']['url']
-                # Livestreams have "runs", non-livestreams have "simpleText",
-                #  and scheduled releases do not have 'viewCountText'
-                if 'viewCountText' in vid_renderer:
-                    if 'runs' in vid_renderer['viewCountText']:
-                        vid_view_count_text = vid_renderer['viewCountText']['runs'][0]['text']
-                    else:
-                        vid_view_count_text = vid_renderer['viewCountText']['simpleText']
-                    # Strip ' views' text, then remove commas
-                    stripped_text = vid_view_count_text.split()[0].replace(',','')
-                    if stripped_text == 'No':
-                        vid_view_count = 0
-                    else:
-                        vid_view_count = int(stripped_text)
-                else:
-                    vid_view_count = 0
-                if 'lengthText' in vid_renderer:
-                    vid_length = vid_renderer['lengthText']['simpleText']
-                else:
-                    vid_length = None
 
-                vid_metadata = {
-                    'id': vid_id,
-                    'url': vid_url,
-                    'title': vid_title,
-                    'channel_name': vid_channel_name,
-                    'channel_url': vid_channel_uri,
-                    'view_count': vid_view_count,
-                    'length': vid_length
-                }
+                # If found element is a Youtube Short video reel
+                if 'reelShelfRenderer' in video_details:
+                    # Extract information from all YT Shorts videos
+                    for reelItemDict in video_details['reelShelfRenderer']['items']:
+                        vid_renderer = reelItemDict['reelItemRenderer']
+                        vid_id = vid_renderer['videoId']
+                        vid_url = f'https://www.youtube.com/watch?v={vid_id}'
+                        vid_title = vid_renderer['headline']['simpleText']
+                        vid_channel_data = \
+                            vid_renderer['navigationEndpoint']['reelWatchEndpoint']['overlay'][
+                                'reelPlayerOverlayRenderer'][
+                                'reelPlayerHeaderSupportedRenderers']['reelPlayerHeaderRenderer']['channelTitleText'][
+                                'runs'][0]
+                        vid_channel_name = vid_channel_data['text']
+                        vid_channel_uri = vid_channel_data['navigationEndpoint']['browseEndpoint']['canonicalBaseUrl']
 
-                # Construct YouTube object from metadata and append to results
-                vid = YouTube(vid_metadata['url'])
-                vid.author = vid_metadata['channel_name']
-                vid.title = vid_metadata['title']
-                videos.append(vid)
+                        vid_metadata = {
+                            'id': vid_id,
+                            'url': vid_url,
+                            'title': vid_title,
+                            'channel_name': vid_channel_name,
+                            'channel_url': vid_channel_uri
+                        }
+                        self.append_video(vid_renderer, vid_metadata, videos)
+                elif 'videoRenderer' in video_details:
+                    vid_renderer = video_details['videoRenderer']
+                    vid_id = vid_renderer['videoId']
+                    vid_url = f'https://www.youtube.com/watch?v={vid_id}'
+                    vid_title = vid_renderer['title']['runs'][0]['text']
+                    vid_channel_name = vid_renderer['ownerText']['runs'][0]['text']
+                    vid_channel_uri = vid_renderer['ownerText']['runs'][0][
+                        'navigationEndpoint']['commandMetadata']['webCommandMetadata']['url']
+
+                    vid_metadata = {
+                        'id': vid_id,
+                        'url': vid_url,
+                        'title': vid_title,
+                        'channel_name': vid_channel_name,
+                        'channel_url': vid_channel_uri
+                    }
+                    self.append_video(vid_renderer, vid_metadata, videos)
         else:
             videos = None
 


### PR DESCRIPTION
ReelShelfRenderer contains 40 items/videos with "Shorts" type. These should not be omitted in the search results as they're normal videos and as such, support for this type of videos was added.

Additionally fixed view count parser, since YouTube gives rounded numbers with K or M as a suffix for "Shorts".

Logic for metadata extraction that is shared between shorts and normal videos was moved to separate static method.