### PR TITLE
Introducing filesize returned in kb, mb and gb

### DIFF
--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -8,6 +8,8 @@ separately).
 """
 import logging
 import os
+from math import ceil
+
 from datetime import datetime
 from typing import BinaryIO, Dict, Optional, Tuple
 from urllib.error import HTTPError
@@ -63,13 +65,13 @@ class Stream:
         self._filesize: Optional[int] = int(stream.get('contentLength', 0))
         
         # filesize in kilobytes
-        self._filesizekb: Optional[int] = round(int(stream.get('contentLength', 0))/1024)
+        self._filesizekb: Optional[float] = float(ceil(stream.get('contentLength', 0) / 1024 * 1000) / 1000)
         
         # filesize in megabytes
-        self._filesizemb: Optional[int] = round(int(stream.get('contentLength', 0))/1024/1024)
+        self._filesizemb: Optional[float] = float(ceil(stream.get('contentLength', 0) / 1024 / 1024 * 1000) / 1000)
         
         # filesize in gigabytes(fingers crossed we don't need terabytes going forward though)
-        self._filesizegb: Optional[int] = round(int(stream.get('contentLength', 0))/1024/1024/1024)
+        self._filesizegb: Optional[float] = float(ceil(stream.get('contentLength', 0) / 1024 / 1024 / 1024 * 1000) / 1000)
 
         # Additional information about the stream format, such as resolution,
         # frame rate, and whether the stream is live (HLS) or 3D.
@@ -160,54 +162,54 @@ class Stream:
         return self._filesize
     
     @property
-    def filesizekb(self) -> int:
+    def filesizekb(self) -> float:
         """File size of the media stream in bytes.
 
-        :rtype: int
+        :rtype: float
         :returns:
             Rounded filesize (in kilobytes) of the stream.
         """
         if self._filesizekb == 0:
             try:
-                self._filesizekb = request.filesize(self.url)/1024
+                self._filesizekb = float(ceil(request.filesize(self.url)/1024 * 1000) / 1000)
             except HTTPError as e:
                 if e.code != 404:
                     raise
-                self._filesizekb = request.seq_filesize(self.url)/1024
+                self._filesizekb = float(ceil(request.seq_filesize(self.url)/1024 * 1000) / 1000)
         return self._filesizekb
     
     @property
-    def filesizemb(self) -> int:
+    def filesizemb(self) -> float:
         """File size of the media stream in bytes.
 
-        :rtype: int
+        :rtype: float
         :returns:
             Rounded filesize (in megabytes) of the stream.
         """
         if self._filesizemb == 0:
             try:
-                self._filesizemb = request.filesize(self.url)/1024/1024
+                self._filesizemb = float(ceil(request.filesize(self.url)/1024/1024 * 1000) / 1000)
             except HTTPError as e:
                 if e.code != 404:
                     raise
-                self._filesizemb = request.seq_filesize(self.url)/1024/1024
+                self._filesizemb = float(ceil(request.seq_filesize(self.url)/1024/1024 * 1000) / 1000)
         return self._filesizemb
 
     @property
-    def filesizegb(self) -> int:
+    def filesizegb(self) -> float:
         """File size of the media stream in bytes.
 
-        :rtype: int
+        :rtype: float
         :returns:
             Rounded filesize (in gigabytes) of the stream.
         """
         if self._filesizegb == 0:
             try:
-                self._filesizegb = request.filesize(self.url)/1024/1024/1024
+                self._filesizegb = float(ceil(request.filesize(self.url)/1024/1024/1024 * 1000) / 1000)
             except HTTPError as e:
                 if e.code != 404:
                     raise
-                self._filesizegb = request.seq_filesize(self.url)/1024/1024/1024
+                self._filesizegb = float(ceil(request.seq_filesize(self.url)/1024/1024/1024 * 1000) / 1000)
         return self._filesizegb
     
     @property

--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -61,6 +61,15 @@ class Stream:
 
         # filesize in bytes
         self._filesize: Optional[int] = int(stream.get('contentLength', 0))
+        
+        # filesize in kilobytes
+        self._filesizekb: Optional[int] = round(int(stream.get('contentLength', 0))/1024)
+        
+        # filesize in megabytes
+        self._filesizemb: Optional[int] = round(int(stream.get('contentLength', 0))/1024/1024)
+        
+        # filesize in gigabytes(fingers crossed we don't need terabytes going forward though)
+        self._filesizegb: Optional[int] = round(int(stream.get('contentLength', 0))/1024/1024/1024)
 
         # Additional information about the stream format, such as resolution,
         # frame rate, and whether the stream is live (HLS) or 3D.
@@ -149,7 +158,58 @@ class Stream:
                     raise
                 self._filesize = request.seq_filesize(self.url)
         return self._filesize
+    
+    @property
+    def filesizekb(self) -> int:
+        """File size of the media stream in bytes.
 
+        :rtype: int
+        :returns:
+            Rounded filesize (in kilobytes) of the stream.
+        """
+        if self._filesizekb == 0:
+            try:
+                self._filesizekb = request.filesize(self.url)/1024
+            except HTTPError as e:
+                if e.code != 404:
+                    raise
+                self._filesizekb = request.seq_filesize(self.url)/1024
+        return self._filesizekb
+    
+    @property
+    def filesizemb(self) -> int:
+        """File size of the media stream in bytes.
+
+        :rtype: int
+        :returns:
+            Rounded filesize (in megabytes) of the stream.
+        """
+        if self._filesizemb == 0:
+            try:
+                self._filesizemb = request.filesize(self.url)/1024/1024
+            except HTTPError as e:
+                if e.code != 404:
+                    raise
+                self._filesizemb = request.seq_filesize(self.url)/1024/1024
+        return self._filesizemb
+
+    @property
+    def filesizegb(self) -> int:
+        """File size of the media stream in bytes.
+
+        :rtype: int
+        :returns:
+            Rounded filesize (in gigabytes) of the stream.
+        """
+        if self._filesizegb == 0:
+            try:
+                self._filesizegb = request.filesize(self.url)/1024/1024/1024
+            except HTTPError as e:
+                if e.code != 404:
+                    raise
+                self._filesizegb = request.seq_filesize(self.url)/1024/1024/1024
+        return self._filesizegb
+    
     @property
     def title(self) -> str:
         """Get title of video

--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -65,13 +65,13 @@ class Stream:
         self._filesize: Optional[int] = int(stream.get('contentLength', 0))
         
         # filesize in kilobytes
-        self._filesizekb: Optional[float] = float(ceil(stream.get('contentLength', 0) / 1024 * 1000) / 1000)
+        self._filesize_kb: Optional[float] = float(ceil(stream.get('contentLength', 0) / 1024 * 1000) / 1000)
         
         # filesize in megabytes
-        self._filesizemb: Optional[float] = float(ceil(stream.get('contentLength', 0) / 1024 / 1024 * 1000) / 1000)
+        self._filesize_mb: Optional[float] = float(ceil(stream.get('contentLength', 0) / 1024 / 1024 * 1000) / 1000)
         
         # filesize in gigabytes(fingers crossed we don't need terabytes going forward though)
-        self._filesizegb: Optional[float] = float(ceil(stream.get('contentLength', 0) / 1024 / 1024 / 1024 * 1000) / 1000)
+        self._filesize_gb: Optional[float] = float(ceil(stream.get('contentLength', 0) / 1024 / 1024 / 1024 * 1000) / 1000)
 
         # Additional information about the stream format, such as resolution,
         # frame rate, and whether the stream is live (HLS) or 3D.
@@ -169,14 +169,14 @@ class Stream:
         :returns:
             Rounded filesize (in kilobytes) of the stream.
         """
-        if self._filesizekb == 0:
+        if self._filesize_kb == 0:
             try:
-                self._filesizekb = float(ceil(request.filesize(self.url)/1024 * 1000) / 1000)
+                self._filesize_kb = float(ceil(request.filesize(self.url)/1024 * 1000) / 1000)
             except HTTPError as e:
                 if e.code != 404:
                     raise
-                self._filesizekb = float(ceil(request.seq_filesize(self.url)/1024 * 1000) / 1000)
-        return self._filesizekb
+                self._filesize_kb = float(ceil(request.seq_filesize(self.url)/1024 * 1000) / 1000)
+        return self._filesize_kb
     
     @property
     def filesizemb(self) -> float:
@@ -186,14 +186,14 @@ class Stream:
         :returns:
             Rounded filesize (in megabytes) of the stream.
         """
-        if self._filesizemb == 0:
+        if self._filesize_mb == 0:
             try:
-                self._filesizemb = float(ceil(request.filesize(self.url)/1024/1024 * 1000) / 1000)
+                self._filesize_mb = float(ceil(request.filesize(self.url)/1024/1024 * 1000) / 1000)
             except HTTPError as e:
                 if e.code != 404:
                     raise
-                self._filesizemb = float(ceil(request.seq_filesize(self.url)/1024/1024 * 1000) / 1000)
-        return self._filesizemb
+                self._filesize_mb = float(ceil(request.seq_filesize(self.url)/1024/1024 * 1000) / 1000)
+        return self._filesize_mb
 
     @property
     def filesizegb(self) -> float:
@@ -203,14 +203,14 @@ class Stream:
         :returns:
             Rounded filesize (in gigabytes) of the stream.
         """
-        if self._filesizegb == 0:
+        if self._filesize_gb == 0:
             try:
-                self._filesizegb = float(ceil(request.filesize(self.url)/1024/1024/1024 * 1000) / 1000)
+                self._filesize_gb = float(ceil(request.filesize(self.url)/1024/1024/1024 * 1000) / 1000)
             except HTTPError as e:
                 if e.code != 404:
                     raise
-                self._filesizegb = float(ceil(request.seq_filesize(self.url)/1024/1024/1024 * 1000) / 1000)
-        return self._filesizegb
+                self._filesize_gb = float(ceil(request.seq_filesize(self.url)/1024/1024/1024 * 1000) / 1000)
+        return self._filesize_gb
     
     @property
     def title(self) -> str:

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -30,14 +30,14 @@ def test_stream_to_buffer(mock_request, cipher_signature):
 def test_filesize(cipher_signature):
     assert cipher_signature.streams[0].filesize == 3399554
     
-def test_filesizekb(cipher_signature):
-    assert cipher_signature.streams[0].filesize == float(3319.877)
+def test_filesize_kb(cipher_signature):
+    assert cipher_signature.streams[0].filesize_kb == float(3319.877)
 
-def test_filesizemb(cipher_signature):
-    assert cipher_signature.streams[0].filesize == float(3.243)
+def test_filesize_mb(cipher_signature):
+    assert cipher_signature.streams[0].filesize_mb == float(3.243)
 
-def test_filesizegb(cipher_signature):
-    assert cipher_signature.streams[0].filesize == float(0.004)
+def test_filesize_gb(cipher_signature):
+    assert cipher_signature.streams[0].filesize_gb == float(0.004)
 
 def test_filesize_approx(cipher_signature):
     stream = cipher_signature.streams[0]

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -31,13 +31,13 @@ def test_filesize(cipher_signature):
     assert cipher_signature.streams[0].filesize == 3399554
     
 def test_filesizekb(cipher_signature):
-    assert cipher_signature.streams[0].filesize == 3320
+    assert cipher_signature.streams[0].filesize == float(3319.877)
 
 def test_filesizemb(cipher_signature):
-    assert cipher_signature.streams[0].filesize == 3
+    assert cipher_signature.streams[0].filesize == float(3.243)
 
 def test_filesizegb(cipher_signature):
-    assert cipher_signature.streams[0].filesize == 0
+    assert cipher_signature.streams[0].filesize == float(0.004)
 
 def test_filesize_approx(cipher_signature):
     stream = cipher_signature.streams[0]

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -29,7 +29,15 @@ def test_stream_to_buffer(mock_request, cipher_signature):
 
 def test_filesize(cipher_signature):
     assert cipher_signature.streams[0].filesize == 3399554
+    
+def test_filesizekb(cipher_signature):
+    assert cipher_signature.streams[0].filesize == 3320
 
+def test_filesizemb(cipher_signature):
+    assert cipher_signature.streams[0].filesize == 3
+
+def test_filesizegb(cipher_signature):
+    assert cipher_signature.streams[0].filesize == 0
 
 def test_filesize_approx(cipher_signature):
     stream = cipher_signature.streams[0]


### PR DESCRIPTION
Adding in properties for the filesize in KB, MB and GB.
These are returned as integers rounded to the nearest significant figure(this because the original filesize attribute is an integer as well and I wanted to continue with that trend)
I have only put in kb, mb and gb, I don't foresee TB large videos on youtube for a while...

The reason I added this in is because I was going to implement this in my own code on top of the pytube library, but I figured it might be better to add it in for everyone else who might use this code base too.

The 2 things I have doubts on are the rounding functionality and integer return type.
if you have set yourself a 1 gigabyte file limit, but the file is 1.45 gb, stream.filesizegb will return 1gb, but a 550mb file will do the same too.
The rounding to return an integer value because the original filesize property returns an int, although for gigabyte large videos, this could mean a +-500mb misrepresentation of the actual file size.  

Happy to discuss with you on the above and find the best solution for this.