### PR TITLE
fix captions.generate_srt_captions()

### DIFF
--- a/pytube/captions.py
+++ b/pytube/captions.py
@@ -67,37 +67,39 @@ class Caption:
 
 
     def xml_caption_to_srt(self, xml_captions: str) -> str:
-        """Convert xml caption tracks to "SubRip Subtitle (srt)".
+      """Convert xml caption tracks to "SubRip Subtitle (srt)".
 
-        :param str xml_captions:
-            XML formatted caption tracks.
-        """
-        segments = []
-        root = ElementTree.fromstring(xml_captions)
-        for i, child in enumerate(list(root.findall('body/p'))):
-            text = ''.join(child.itertext()).strip()
-            if not text:
-                continue
-            caption = unescape(text.replace("\n", " ").replace("  ", " "),)
-            try:
-                duration = float(child.attrib["d"])
-            except KeyError:
-                duration = 0.0
-            start = float(child.attrib["t"])
-            try:
-                end = float(root.findall('body/p')[i+2].attrib['t'])
-            except:
-                end = float(root.findall('body/p')[i].attrib['t']) + duration
-            sequence_number = i + 1  # convert from 0-indexed to 1.
-            line = "{seq}\n{start} --> {end}\n{text}\n".format(
-                seq=sequence_number,
-                start=self.float_to_srt_time_format(start),
-                end=self.float_to_srt_time_format(end),
-                text=caption,
-            )
-            segments.append(line)
-
-        return "\n".join(segments).strip()
+      :param str xml_captions:
+          XML formatted caption tracks.
+      """
+      segments = []
+      root = ElementTree.fromstring(xml_captions)[1]
+      i=0
+      for child in list(root):
+          if child.tag == 'p':
+              caption = ''
+              if len(list(child))==0:
+                  continue
+              for s in list(child):
+                  if s.tag == 's':
+                      caption += ' ' + s.text
+              caption = unescape(caption.replace("\n", " ").replace("  ", " "),)
+              try:
+                  duration = float(child.attrib["d"])/1000.0
+              except KeyError:
+                  duration = 0.0
+              start = float(child.attrib["t"])/1000.0
+              end = start + duration
+              sequence_number = i + 1  # convert from 0-indexed to 1.
+              line = "{seq}\n{start} --> {end}\n{text}\n".format(
+                  seq=sequence_number,
+                  start=self.float_to_srt_time_format(start),
+                  end=self.float_to_srt_time_format(end),
+                  text=caption,
+              )
+              segments.append(line)
+              i += 1
+      return "\n".join(segments).strip()
 
 
     def download(


### PR DESCRIPTION
Seems that recently Youtube changed how it handles captions, and now captions.generate_srt_captions() is broken:

```
yc = yt.captions['en']
a = yc.generate_srt_captions()

Traceback (most recent call last):
  File "/home/tony/github/videorhyme/videorhyme/youtube_dl/test.py", line 6, in <module>
    a = yc.generate_srt_captions()
  File "/home/tony/miniconda3/envs/videorhyme/lib/python3.10/site-packages/pytube/captions.py", line 51, in generate_srt_captions
    return self.xml_caption_to_srt(self.xml_captions)
  File "/home/tony/miniconda3/envs/videorhyme/lib/python3.10/site-packages/pytube/captions.py", line 83, in xml_caption_to_srt
    start = float(child.attrib["start"])
KeyError: 'start'
```

This PR fixes that problem. I took this code from a [year old issue report](https://github.com/pytube/pytube/issues/1085#issuecomment-927227541) and it seems to work.