### PR TITLE
Adding fix for KeyError: sidebar

### DIFF
--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -353,9 +353,12 @@ class Playlist(Sequence):
 
     @property
     def description(self) -> str:
+        if len(self.sidebar_info[0]['playlistSidebarPrimaryInfoRenderer']['description']) == 0:
+            return ""
+        
         return self.sidebar_info[0]['playlistSidebarPrimaryInfoRenderer'][
             'description']['simpleText']
-
+            
     @property
     def length(self):
         """Extract the number of videos in the playlist.


### PR DESCRIPTION
See issue #1404 for a description of the problem and #1406 for the solution proposed by @PugPickles. 

The recent YouTube formatting changes required this fix for how sidebar info is obtained. When attempting to access Playlist properties, such as the title, a "KeyError: sidebar" was encountered.

This fix simply checks if the "description" property of the sidebar exists before attempting to return it, returning an empty string if there is no description.