### PR TITLE
Fix empty channel videos

### DIFF
--- a/pytube/contrib/channel.py
+++ b/pytube/contrib/channel.py
@@ -151,9 +151,7 @@ class Channel(Playlist):
             videos = initial_data["contents"][
                 "twoColumnBrowseResultsRenderer"][
                 "tabs"][1]["tabRenderer"]["content"][
-                "sectionListRenderer"]["contents"][0][
-                "itemSectionRenderer"]["contents"][0][
-                "gridRenderer"]["items"]
+                "richGridRenderer"]["contents"]
         except (KeyError, IndexError, TypeError):
             try:
                 # this is the json tree structure, if the json was directly sent
@@ -191,7 +189,7 @@ class Channel(Playlist):
                     map(
                         lambda x: (
                             f"/watch?v="
-                            f"{x['gridVideoRenderer']['videoId']}"
+                            f"{x['richItemRenderer']['content']['videoRenderer']['videoId']}"
                         ),
                         videos
                     )


### PR DESCRIPTION
Fixed a bug that caused the channel's video list to be empty.

Support for Youtube html changes
Issue:https://github.com/pytube/pytube/issues/1408
