### PR TITLE
Fix empty channel videos, live and shorts

### DIFF
--- a/pytube/contrib/channel.py
+++ b/pytube/contrib/channel.py
@@ -337,6 +337,16 @@ class Channel(Playlist):
             return None
 
     @property
+    def thumbnail_url(self) -> str:
+        """extract the profile image from the json of the channel home page
+
+        :rtype: str
+        :return: a string with the url of the channel's profile image
+        """
+        self.html_url = self.channel_url  # get the url of the channel home page
+        return self.initial_data['metadata']['channelMetadataRenderer']['avatar']['thumbnails'][0]['url']
+
+    @property
     def videos(self) -> Iterable[YouTube]:
         """Yields YouTube objects of videos in this channel
 

--- a/pytube/contrib/channel.py
+++ b/pytube/contrib/channel.py
@@ -33,7 +33,7 @@ class Channel(Playlist):
         self.featured_channels_url = self.channel_url + '/channels'
         self.about_url = self.channel_url + '/about'
 
-        self._html_page = self.videos_url  # Videos will be preferred over short videos
+        self._html_url = self.videos_url  # Videos will be preferred over short videos
         self._visitor_data = None
 
         # Possible future additions
@@ -71,6 +71,24 @@ class Channel(Playlist):
         return self.initial_data['metadata']['channelMetadataRenderer'].get('vanityChannelUrl', None)  # noqa:E501
 
     @property
+    def html_url(self):
+        """Get the html url.
+
+        :rtype: str
+        """
+        return self._html_url
+
+    @html_url.setter
+    def html_url(self, value):
+        """Set the html url and clear the cache."""
+        if self._html_url != value:
+            self._html = None
+            self.__class__.video_urls.fget.cache_clear()
+            self.__class__.last_updated.fget.cache_clear()
+            self.__class__.title.fget.cache_clear()
+            self._html_url = value
+
+    @property
     def html(self):
         """Get the html for the /videos or /shorts page.
 
@@ -78,7 +96,7 @@ class Channel(Playlist):
         """
         if self._html:
             return self._html
-        self._html = request.get(self._html_page)
+        self._html = request.get(self.html_url)
         return self._html
 
     @property
@@ -253,7 +271,7 @@ class Channel(Playlist):
         :rtype: List[YouTube]
         :returns: List of YouTube
         """
-        self._html_page = self.videos_url  # Set video tab
+        self.html_url = self.videos_url  # Set video tab
         return DeferredGeneratorList(self.videos_generator())
 
     @property
@@ -263,5 +281,5 @@ class Channel(Playlist):
        :rtype: List[YouTube]
        :returns: List of YouTube
        """
-        self._html_page = self.shorts_url  # Set shorts tab
+        self.html_url = self.shorts_url  # Set shorts tab
         return DeferredGeneratorList(self.videos_generator())

--- a/pytube/contrib/channel.py
+++ b/pytube/contrib/channel.py
@@ -2,10 +2,10 @@
 """Module for interacting with a user's youtube channel."""
 import json
 import logging
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Iterable
 
-from pytube import extract, Playlist, request
-from pytube.helpers import uniqueify
+from pytube import extract, YouTube, Playlist, request
+from pytube.helpers import uniqueify, DeferredGeneratorList
 
 logger = logging.getLogger(__name__)
 
@@ -13,7 +13,6 @@ logger = logging.getLogger(__name__)
 class Channel(Playlist):
     def __init__(self, url: str, proxies: Optional[Dict[str, str]] = None):
         """Construct a :class:`Channel <Channel>`.
-
         :param str url:
             A valid YouTube channel URL.
         :param proxies:
@@ -28,10 +27,14 @@ class Channel(Playlist):
         )
 
         self.videos_url = self.channel_url + '/videos'
+        self.shorts_url = self.channel_url + '/shorts'
         self.playlists_url = self.channel_url + '/playlists'
         self.community_url = self.channel_url + '/community'
         self.featured_channels_url = self.channel_url + '/channels'
         self.about_url = self.channel_url + '/about'
+
+        self._html_page = self.videos_url  # Videos will be preferred over short videos
+        self._visitor_data = None
 
         # Possible future additions
         self._playlists_html = None
@@ -69,13 +72,13 @@ class Channel(Playlist):
 
     @property
     def html(self):
-        """Get the html for the /videos page.
+        """Get the html for the /videos or /shorts page.
 
         :rtype: str
         """
         if self._html:
             return self._html
-        self._html = request.get(self.videos_url)
+        self._html = request.get(self._html_page)
         return self._html
 
     @property
@@ -134,8 +137,41 @@ class Channel(Playlist):
             self._about_html = request.get(self.about_url)
             return self._about_html
 
-    @staticmethod
-    def _extract_videos(raw_json: str) -> Tuple[List[str], Optional[str]]:
+    def _build_continuation_url(self, continuation: str) -> Tuple[str, dict, dict]:
+        """Helper method to build the url and headers required to request
+        the next page of videos
+
+        :param str continuation: Continuation extracted from the json response
+            of the last page
+        :rtype: Tuple[str, dict, dict]
+        :returns: Tuple of an url and required headers for the next http
+            request
+        """
+        return (
+            (
+                # was changed to this format (and post requests)
+                # between 2022.11.06 and 2022.11.20
+                "https://www.youtube.com/youtubei/v1/browse?key="
+                f"{self.yt_api_key}"
+            ),
+            {
+                "X-YouTube-Client-Name": "1",
+                "X-YouTube-Client-Version": "2.20200720.00.02",
+            },
+            # extra data required for post request
+            {
+                "continuation": continuation,
+                "context": {
+                    "client": {
+                        "clientName": "WEB",
+                        "visitorData": self._visitor_data,
+                        "clientVersion": "2.20200720.00.02"
+                    }
+                }
+            }
+        )
+
+    def _extract_videos(self, raw_json: str) -> Tuple[List[str], Optional[str]]:
         """Extracts videos from a raw json page
 
         :param str raw_json: Input json extracted from the page or the last
@@ -148,12 +184,23 @@ class Channel(Playlist):
         # this is the json tree structure, if the json was extracted from
         # html
         try:
-            videos = initial_data["contents"][
-                "twoColumnBrowseResultsRenderer"][
-                "tabs"][1]["tabRenderer"]["content"][
-                "sectionListRenderer"]["contents"][0][
-                "itemSectionRenderer"]["contents"][0][
-                "gridRenderer"]["items"]
+            try:
+                # This is the json tree structure for videos
+                videos = initial_data["contents"][
+                    "twoColumnBrowseResultsRenderer"][
+                    "tabs"][1]["tabRenderer"]["content"]["richGridRenderer"]["contents"]
+
+            except(KeyError, IndexError, TypeError):
+                # This is the json tree structure for short videos
+                videos = initial_data["contents"][
+                    "twoColumnBrowseResultsRenderer"][
+                    "tabs"][2]["tabRenderer"]["content"]["richGridRenderer"]["contents"]
+
+            # This is the json tree structure of visitor data
+            # It is necessary to send the visitorData together with the continuation token
+            self._visitor_data = initial_data["responseContext"]["webResponseContextExtensionData"][
+                "ytConfigData"]["visitorData"]
+
         except (KeyError, IndexError, TypeError):
             try:
                 # this is the json tree structure, if the json was directly sent
@@ -183,19 +230,38 @@ class Channel(Playlist):
             # if there is an error, no continuation is available
             continuation = None
 
+        # only extract the video ids from the video data
+        videos_url = []
+        try:
+            # Extract id from videos
+            for x in videos:
+                videos_url.append(f"/watch?v="
+                                  f"{x['richItemRenderer']['content']['videoRenderer']['videoId']}")
+        except (KeyError, IndexError, TypeError):
+            # Extract id from short videos
+            for x in videos:
+                videos_url.append(f"/watch?v="
+                                  f"{x['richItemRenderer']['content']['reelItemRenderer']['videoId']}")
+
         # remove duplicates
-        return (
-            uniqueify(
-                list(
-                    # only extract the video ids from the video data
-                    map(
-                        lambda x: (
-                            f"/watch?v="
-                            f"{x['gridVideoRenderer']['videoId']}"
-                        ),
-                        videos
-                    )
-                ),
-            ),
-            continuation,
-        )
+        return uniqueify(videos_url), continuation
+
+    @property
+    def videos(self) -> Iterable[YouTube]:
+        """Yields YouTube objects of videos in this channel
+
+        :rtype: List[YouTube]
+        :returns: List of YouTube
+        """
+        self._html_page = self.videos_url  # Set video tab
+        return DeferredGeneratorList(self.videos_generator())
+
+    @property
+    def shorts(self) -> Iterable[YouTube]:
+        """Yields YouTube objects of short videos in this channel
+
+       :rtype: List[YouTube]
+       :returns: List of YouTube
+       """
+        self._html_page = self.shorts_url  # Set shorts tab
+        return DeferredGeneratorList(self.videos_generator())

--- a/pytube/extract.py
+++ b/pytube/extract.py
@@ -160,6 +160,7 @@ def channel_name(url: str) -> str:
     - :samp:`https://youtube.com/channel/{channel_id}/*
     - :samp:`https://youtube.com/u/{channel_name}/*`
     - :samp:`https://youtube.com/user/{channel_id}/*
+    - :samp:`https://youtube.com/@{channel_id}/*
 
     :param str url:
         A YouTube url containing a channel name.
@@ -171,7 +172,8 @@ def channel_name(url: str) -> str:
         r"(?:\/(c)\/([%\d\w_\-]+)(\/.*)?)",
         r"(?:\/(channel)\/([%\w\d_\-]+)(\/.*)?)",
         r"(?:\/(u)\/([%\d\w_\-]+)(\/.*)?)",
-        r"(?:\/(user)\/([%\w\d_\-]+)(\/.*)?)"
+        r"(?:\/(user)\/([%\w\d_\-]+)(\/.*)?)",
+        r"(?:\/(\@)([%\d\w_\-]+)(\/.*)?)"
     ]
     for pattern in patterns:
         regex = re.compile(pattern)
@@ -180,7 +182,7 @@ def channel_name(url: str) -> str:
             logger.debug("finished regex search, matched: %s", pattern)
             uri_style = function_match.group(1)
             uri_identifier = function_match.group(2)
-            return f'/{uri_style}/{uri_identifier}'
+            return f'/{uri_style}/{uri_identifier}' if uri_style != '@' else f'/{uri_style}{uri_identifier}'
 
     raise RegexMatchError(
         caller="channel_name", pattern="patterns"

--- a/pytube/extract.py
+++ b/pytube/extract.py
@@ -173,7 +173,7 @@ def channel_name(url: str) -> str:
         r"(?:\/(channel)\/([%\w\d_\-]+)(\/.*)?)",
         r"(?:\/(u)\/([%\d\w_\-]+)(\/.*)?)",
         r"(?:\/(user)\/([%\w\d_\-]+)(\/.*)?)",
-        r"(?:\/(\@)([%\d\w_\-]+)(\/.*)?)"
+        r"(?:\/(\@)([%\d\w_\-\.]+)(\/.*)?)"
     ]
     for pattern in patterns:
         regex = re.compile(pattern)


### PR DESCRIPTION
### Added support for shorts #1418 

Youtube changed html page, post data and json tree.

Now it is necessary to send a VisitorData in the continuation post.

Added `.shorts` property to get them from channels.

### Fixed empty video list #1408 
When youtube changed the shorts tab it also changed the json tree of the videos.

### Adding regex support to get new channel url style #1420 
In the recent youtube update it allowed channels to add custom names in the url 
"**@**" is now used before the channel name.

### Updated getting active tabs. [suggestion](https://github.com/pytube/pytube/pull/1422/files#r1030883623)

As youtube does not have a fixed index of each tab, 
we check if the url in the json tree of each tab is equal to the desired url.


### Added support for live. [solicitation](https://github.com/pytube/pytube/pull/1422/files#r1030118335)

Added `.live` property to get them from channels.