### PR TITLE
New channel_name extract func with tests

### DIFF
--- a/pytube/extract.py
+++ b/pytube/extract.py
@@ -156,8 +156,12 @@ def channel_name(url: str) -> str:
 
     This function supports the following patterns:
 
+    - :samp:`https://youtube.com/{channel_name}/*`
+    - :samp:`https://youtube.com/@{channel_name}/*`
     - :samp:`https://youtube.com/c/{channel_name}/*`
     - :samp:`https://youtube.com/channel/{channel_id}/*
+    - :samp:`https://youtube.com/c/@{channel_name}/*`
+    - :samp:`https://youtube.com/channel/@{channel_id}/*
     - :samp:`https://youtube.com/u/{channel_name}/*`
     - :samp:`https://youtube.com/user/{channel_id}/*
 
@@ -167,24 +171,20 @@ def channel_name(url: str) -> str:
     :returns:
         YouTube channel name.
     """
-    patterns = [
-        r"(?:\/(c)\/([%\d\w_\-]+)(\/.*)?)",
-        r"(?:\/(channel)\/([%\w\d_\-]+)(\/.*)?)",
-        r"(?:\/(u)\/([%\d\w_\-]+)(\/.*)?)",
-        r"(?:\/(user)\/([%\w\d_\-]+)(\/.*)?)"
-    ]
-    for pattern in patterns:
-        regex = re.compile(pattern)
-        function_match = regex.search(url)
-        if function_match:
-            logger.debug("finished regex search, matched: %s", pattern)
-            uri_style = function_match.group(1)
-            uri_identifier = function_match.group(2)
-            return f'/{uri_style}/{uri_identifier}'
+    pattern = r"(?:https?:\/\/)?(?:www\.)?youtube\.com\/(?:(user|channel|c)(?:\/))?\@?([%\d\w_\-]+)"
+    regex = re.compile(pattern)
+    function_match = regex.search(url)
+    if function_match:
+        logger.debug("finished regex search, matched: %s", pattern)
+        uri_style = function_match.group(1)
+        uri_style = uri_style if uri_style else "c"
+        uri_identifier = function_match.group(2)
+        return f'/{uri_style}/{uri_identifier}'
+    else:
+        raise RegexMatchError(
+            caller="channel_name", pattern="patterns"
+        )
 
-    raise RegexMatchError(
-        caller="channel_name", pattern="patterns"
-    )
 
 
 def video_info_url(video_id: str, watch_url: str) -> str:

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -2,6 +2,7 @@
 from datetime import datetime
 import pytest
 import re
+import itertools
 
 from pytube import extract
 from pytube.exceptions import RegexMatchError
@@ -75,6 +76,27 @@ def test_mime_type_codec():
     )
     assert mime_type == "audio/webm"
     assert mime_subtype == ["opus"]
+
+
+def test_channel_name():
+    options = [
+        ["http://", "https://", ""],
+        ["www.", ""],
+        ["youtube.com/"],
+        ["c/", "channel/", "user/", ""],
+        ["CHANNELNAME", "@CHANNELNAME"],
+        ["/extra", ""]
+    ]
+    for opt in itertools.product(*options):
+        url = "".join(opt)
+        channel_name = extract.channel_name(url)
+        assert channel_name in {'/c/CHANNELNAME', '/channel/CHANNELNAME', '/user/CHANNELNAME'}
+
+
+@pytest.mark.parametrize("bad_url", ["", "youtube.com/", "google.com/CHANNELNAME"])
+def test_channel_name_incorrect_should_error(bad_url):
+    with pytest.raises(RegexMatchError):
+        extract.channel_name(bad_url)
 
 
 def test_mime_type_codec_with_no_match_should_error():


### PR DESCRIPTION
This PR adds support for the new Youtube handles (@channel_name), and direct links without a uri_style like youtube.com/channel_name. See https://support.google.com/youtube/answer/11585688?hl=en