### PR TITLE
`YouTube.from_id` — YouTube object with just the video id

### DIFF
--- a/pytube/__main__.py
+++ b/pytube/__main__.py
@@ -465,3 +465,15 @@ class YouTube:
 
         """
         self.stream_monostate.on_complete = func
+
+    @staticmethod
+    def from_id(video_id: str) -> "YouTube":
+        """Construct a :class:`YouTube <YouTube>` object from a video id.
+
+        :param str video_id:
+            The video id of the YouTube video.
+
+        :rtype: :class:`YouTube <YouTube>`
+        
+        """
+        return YouTube(f"https://www.youtube.com/watch?v={video_id}")


### PR DESCRIPTION
Allow creating a YouTube object without having the full url, just the video id


```py
from pytube import YouTube

thrinterview_id = 'Gg1rCpchsno'
YouTube.from_id(thrinterview_id)
```
