### PR TITLE
Minor documentation fix (add missing import to example)

### DIFF
--- a/docs/user/exceptions.rst
+++ b/docs/user/exceptions.rst
@@ -13,6 +13,7 @@ videos in a playlist, videos that are region-restricted, and more.
 Let's see what your code might look like if you need to do exception handling::
 
     >>> from pytube import Playlist, YouTube
+    >>> from pytube.exceptions import VideoUnavailable
     >>> playlist_url = 'https://youtube.com/playlist?list=special_playlist_id'
     >>> p = Playlist(playlist_url)
     >>> for url in p.video_urls:


### PR DESCRIPTION
Need to import `VideoUnavailable` exception to [this example](https://pytube.io/en/latest/user/exceptions.html).