### PR TITLE
Resolve Pytube Issue #1498

### DIFF
--- a/pytube/cipher.py
+++ b/pytube/cipher.py
@@ -408,7 +408,7 @@ def get_throttling_plan(js: str):
     plan_regex = re.compile(transform_start)
     match = plan_regex.search(raw_code)
 
-    transform_plan_raw = find_object_from_startpoint(raw_code, match.span()[1] - 1)
+    transform_plan_raw = js
 
     # Steps are either c[x](c[y]) or c[x](c[y],c[z])
     step_start = r"c\[(\d+)\]\(c\[(\d+)\](,c(\[(\d+)\]))?\)"


### PR DESCRIPTION
Resolves #1498 by modifying 'cipher.py' line 411 to "transform_plan_raw = js".
This issue was most likely caused by a change made by YouTube.
All credit goes to @dark9ive for fixing the issue.