### PR TITLE
Quick Fix to recent issue!

### DIFF
--- a/pytube/cipher.py
+++ b/pytube/cipher.py
@@ -408,7 +408,7 @@ def get_throttling_plan(js: str):
     plan_regex = re.compile(transform_start)
     match = plan_regex.search(raw_code)
 
-    transform_plan_raw = find_object_from_startpoint(raw_code, match.span()[1] - 1)
+    transform_plan_raw = js
 
     # Steps are either c[x](c[y]) or c[x](c[y],c[z])
     step_start = r"c\[(\d+)\]\(c\[(\d+)\](,c(\[(\d+)\]))?\)"


### PR DESCRIPTION
**cipher.py: AttributeError: ‘NoneType’ object has no attribute ‘span’----->>**
REPLACED “transform_plan_raw = find_object_from_startpoint(raw_code, match.span()[1] — 1)” to “transform_plan_raw = js”