### PR TITLE
fix: fix 'json' is not defined

### DIFF
--- a/pytube/captions.py
+++ b/pytube/captions.py
@@ -4,6 +4,7 @@ import time
 import xml.etree.ElementTree as ElementTree
 from html import unescape
 from typing import Dict, Optional
+import json
 
 from pytube import request
 from pytube.helpers import safe_filename, target_directory
@@ -45,11 +46,15 @@ class Caption:
     @property
     def json_captions(self) -> dict:
         """Download and parse the json caption tracks."""
-        json_captions_url = self.url.replace('fmt=srv3','fmt=json3')
+        json_captions_url = self.get_url_for_json()
         text = request.get(json_captions_url)
         parsed = json.loads(text)
         assert parsed['wireMagic'] == 'pb3', 'Unexpected captions format'
         return parsed
+
+    def get_url_for_json(self) -> str:
+        """Format the URL, for getting the JSON"""
+        return self.url.replace('fmt=srv3', 'fmt=json3')
 
     def generate_srt_captions(self) -> str:
         """Generate "SubRip Subtitle" captions.

--- a/tests/test_captions.py
+++ b/tests/test_captions.py
@@ -148,6 +148,40 @@ def test_xml_captions(request_get):
     assert caption.xml_captions == "test"
 
 
+@mock.patch("pytube.request.get")
+@mock.patch("pytube.captions.Caption.get_url_for_json")
+def test_json_caption(mock_url, mock_resp):
+    mock_url.return_value = "test"
+
+    caption = Caption(
+        {"url": "url1", "name": {"simpleText": "name1"}, "languageCode": "en", "vssId": ".en"}
+    )
+
+    mock_resp.return_value = """{
+        "wireMagic": "pb3", "pens": [{}], "wsWinStyles": [{}], "wpWinPositions": [{}],
+          "events": [{
+              "tStartMs": 1120,"dDurationMs": 2640,
+              "segs": [{"utf8": "In this course, you're going to learn\neverything you need to know to get"}]},
+            {
+              "tStartMs": 3760,"dDurationMs": 3039,
+              "segs": [{"utf8": "started with Git.\nIf you're an absolute beginner or if you"}]}
+          ]}""".replace("\n", " ")
+
+    assert caption.json_captions == {
+        'wireMagic': 'pb3', 'pens': [{}], 'wsWinStyles': [{}], 'wpWinPositions': [{}],
+        'events': [
+            {'tStartMs': 1120, 'dDurationMs': 2640,
+             'segs': [{
+                 'utf8': "In this course, you're going to learn everything you need to know to get"
+             }]},
+            {'tStartMs': 3760, 'dDurationMs': 3039,
+             'segs': [{
+                 'utf8': "started with Git. If you're an absolute beginner or if you"
+             }]}
+        ]
+    }
+
+
 @mock.patch("pytube.captions.request")
 def test_generate_srt_captions(request):
     request.get.return_value = (


### PR DESCRIPTION
This fixes the error occuring when try to get the JSON Caption.

BREAKING CHANGE
Before this fixes, NameError occurs, and can't get the json_caption

Closes #1535

test: add test case for test_captions

This test case adds the testing of the json_caption() function. Add the get_url_for_json() function for this purpose.