### PR TITLE
Update innertube.py: changed ANDROID to WEB to fix KeyError

### DIFF
--- a/pytube/innertube.py
+++ b/pytube/innertube.py
@@ -75,7 +75,7 @@ _token_file = os.path.join(_cache_dir, 'tokens.json')
 
 class InnerTube:
     """Object for interacting with the innertube API."""
-    def __init__(self, client='ANDROID', use_oauth=False, allow_cache=True):
+    def __init__(self, client='WEB', use_oauth=False, allow_cache=True):
         """Initialize an InnerTube object.
 
         :param str client:


### PR DESCRIPTION
This fixed "KeyError: 'videoDetails' ; Exception while accessing title of ...." (and similar) bug for me.  Seems it never more works for 'ANDROID'.

This is  a quck fix to make it work - not sure if it won't break anything in different place.