### PR TITLE
Embed playback issue: When embed playback is blocked, pytube would detect it as age restriction

### DIFF
--- a/pytube/exceptions.py
+++ b/pytube/exceptions.py
@@ -52,6 +52,19 @@ class VideoUnavailable(PytubeError):
     def error_string(self):
         return f'{self.video_id} is unavailable'
 
+class EmbedPlaybackDisabled(VideoUnavailable):
+    """Playback on other websites has been disabled by the video owner."""
+    def __init__(self, video_id: str):
+        """
+        :param str video_id:
+            A YouTube video identifier.
+        """
+        self.video_id = video_id
+        super().__init__(self.video_id)
+
+    @property
+    def error_string(self):
+        return f"{self.video_id} can only be reproduced on the youtube website."
 
 class AgeRestrictedError(VideoUnavailable):
     """Video is age restricted, and cannot be accessed without OAuth."""


### PR DESCRIPTION
Hello. This morning while running some test downloads I ran into an issue with the following video: https://www.youtube.com/watch?v=e8RcQoGY4OE

Pytube would detect it as Age restricted even though it is not. After some digging I found it was due to the video having embed playback blocked.  

The current solution in this PR will check the if reason for no playability is present in the newly introduced map and obtain which player to use to work around it.

This solution could be problematic in the future for two reasons:
 - Are the reasons for no playability always in english?
 - Is it often that they change the text? If so, maybe we would need to interpret the reason with searching some string in it.. (like "embed" or "website")


Here are some links for you to test:
1. The link that is not allowed in embedded: https://www.youtube.com/watch?v=e8RcQoGY4OE  which should now be downloaded correctly (previously would throw age restriction exception)
2. An Eminem song that is age restricted and will properly throw the exception: https://www.youtube.com/watch?v=mQvteoFiMlg
3. Pick any other video from youtube and it should still work as originally