### PR TITLE
Cli fails to work when target is passed as the only option

### DIFF
--- a/pytube/cli.py
+++ b/pytube/cli.py
@@ -66,6 +66,10 @@ def _perform_args_on_youtube(
         display_streams(youtube)
     if args.build_playback_report:
         build_playback_report(youtube)
+    if args.target:
+        download_highest_resolution_progressive(
+            youtube=youtube, resolution="highest", target=args.target
+        )
     if args.itag:
         download_by_itag(youtube=youtube, itag=args.itag, target=args.target)
     if args.caption_code:


### PR DESCRIPTION
The command line fails to work when target is passed as the only option

**Reproducible Example**

    pytube -t ./downloads https://www.youtube.com/shorts/D9j1qrrhOgo

it displays the log "Loading video..." but does not download the video itself,
however it works if another option is passed:

    pytube -t ./downloads -itag 17 https://www.youtube.com/shorts/D9j1qrrhOgo

**Explanation**

The series of if statements in _perform_args_on_youtube function does not handle the case when target option is passed alone, in this way no if statement turns out to be true and the program just quits. On the other hand when passing another option, like itag, there is one if statement that turns out to be true and  the target option is passed there, so the video is actually downloaded and stored in the target folder