### PR TITLE
Let cli download video passing -r even if they are not progressive mp4 - fix #1369

### DIFF
--- a/pytube/query.py
+++ b/pytube/query.py
@@ -250,8 +250,6 @@ class StreamQuery(Sequence):
     def get_by_resolution(self, resolution: str) -> Optional[Stream]:
         """Get the corresponding :class:`Stream <Stream>` for a given resolution.
 
-        Stream must be a progressive mp4.
-
         :param str resolution:
             Video resolution i.e. "720p", "480p", "360p", "240p", "144p"
         :rtype: :class:`Stream <Stream>` or None
@@ -260,9 +258,7 @@ class StreamQuery(Sequence):
             not found.
 
         """
-        return self.filter(
-            progressive=True, subtype="mp4", resolution=resolution
-        ).first()
+        return self.filter(resolution=resolution).first()
 
     def get_lowest_resolution(self) -> Optional[Stream]:
         """Get lowest resolution stream that is a progressive mp4.


### PR DESCRIPTION

### Explanation
read here https://github.com/pytube/pytube/issues/1639

### Testing

Tried to run the test suite with pytest even before this pull but it looks like many tests throw errors and I did not find any explanation/docs for that...

So to test this pull, I simply tried to download all available resolutions for a target video, here is the code:

    pytube -l https://www.youtube.com/shorts/pPE8SWmwWJ4 > streams.tmp

    cat streams.tmp | grep video | cut -d " " -f4 | cut -d "=" -f2 | grep "p" | sort | uniq | sed 's/"//g' > resolutions.tmp

    for r in $(cat resolutions.tmp); do pytube -r $r https://www.youtube.com/shorts/pPE8SWmwWJ4; done