### PR TITLE
Update cipher.py fix "pytube.exceptions.RegexMatchError: get_throttling_function_name: could not find match for multiple " for pytube 15.0.0

### DIFF
--- a/pytube/cipher.py
+++ b/pytube/cipher.py
@@ -269,7 +269,7 @@ def get_throttling_function_name(js: str) -> str:
         # a.C && (b = a.get("n")) && (b = Bpa[0](b), a.set("n", b),
         # Bpa.length || iha("")) }};
         # In the above case, `iha` is the relevant function name
-        r'a\.[a-zA-Z]\s*&&\s*\([a-z]\s*=\s*a\.get\("n"\)\)\s*&&\s*'
+        r'a\.[a-zA-Z]\s*&&\s*\([a-z]\s*=\s*a\.get\("n"\)\)\s*&&.*?\|\|\s*([a-z]+)',
         r'\([a-z]\s*=\s*([a-zA-Z0-9$]+)(\[\d+\])?\([a-z]\)',
     ]
     logger.debug('Finding throttling function name')


### PR DESCRIPTION
fix this error "pytube.exceptions.RegexMatchError: get_throttling_function_name: could not find match for multiple "