### PR TITLE
Fix **get_throttling_function_name: could not find match for multiple**

### DIFF
--- a/pytube/cipher.py
+++ b/pytube/cipher.py
@@ -269,7 +269,7 @@ def get_throttling_function_name(js: str) -> str:
         # a.C && (b = a.get("n")) && (b = Bpa[0](b), a.set("n", b),
         # Bpa.length || iha("")) }};
         # In the above case, `iha` is the relevant function name
-        r'a\.[a-zA-Z]\s*&&\s*\([a-z]\s*=\s*a\.get\("n"\)\)\s*&&\s*'
+        r'a\.[a-zA-Z]\s*&&\s*\([a-z]\s*=\s*a\.get\("n"\)\)\s*&&.*?\|\|\s*([a-z]+)',
         r'\([a-z]\s*=\s*([a-zA-Z0-9$]+)(\[\d+\])?\([a-z]\)',
     ]
     logger.debug('Finding throttling function name')

--- a/pytube/cipher.py
+++ b/pytube/cipher.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 class Cipher:
     def __init__(self, js: str):
         self.transform_plan: List[str] = get_transform_plan(js)
-        var_regex = re.compile(r"^\$*\w+\W")
+        var_regex = re.compile(r"^\$?\w+\W")
         var_match = var_regex.search(self.transform_plan[0])
         if not var_match:
             raise RegexMatchError(

--- a/pytube/cipher.py
+++ b/pytube/cipher.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 class Cipher:
     def __init__(self, js: str):
         self.transform_plan: List[str] = get_transform_plan(js)
-        var_regex = re.compile(r"^[\w\$_]+\W") # fix the regex issue that was causing the error in downloading the video
+        var_regex = re.compile(r"^\$*\w+\W")
         var_match = var_regex.search(self.transform_plan[0])
         if not var_match:
             raise RegexMatchError(

--- a/pytube/cipher.py
+++ b/pytube/cipher.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 class Cipher:
     def __init__(self, js: str):
         self.transform_plan: List[str] = get_transform_plan(js)
-        var_regex = re.compile(r"^\w+\W")
+        var_regex = re.compile(r"^[\w\$_]+\W") # fix the regex issue that was causing the error in downloading the video
         var_match = var_regex.search(self.transform_plan[0])
         if not var_match:
             raise RegexMatchError(

--- a/pytube/version.py
+++ b/pytube/version.py
@@ -1,4 +1,4 @@
-__version__ = "15.0.0"
+__version__ = "15.0.1"
 
 if __name__ == "__main__":
     print(__version__)

--- a/pytube/version.py
+++ b/pytube/version.py
@@ -1,4 +1,4 @@
-__version__ = "15.0.1"
+__version__ = "15.0.2"
 
 if __name__ == "__main__":
     print(__version__)

--- a/pytube/version.py
+++ b/pytube/version.py
@@ -1,4 +1,4 @@
-__version__ = "15.0.0"
+__version__ = "15.0.2"
 
 if __name__ == "__main__":
     print(__version__)

--- a/pytube/version.py
+++ b/pytube/version.py
@@ -1,4 +1,4 @@
-__version__ = "15.0.3"
+__version__ = "15.0.4"
 
 if __name__ == "__main__":
     print(__version__)

--- a/pytube/version.py
+++ b/pytube/version.py
@@ -1,4 +1,4 @@
-__version__ = "15.0.2"
+__version__ = "15.0.3"
 
 if __name__ == "__main__":
     print(__version__)


### PR DESCRIPTION
This little fix solve the bug:

```
pytube.exceptions.RegexMatchError: get_throttling_function_name: could not find match for multiple
```

It is base on the last solution on [stack overflow](https://stackoverflow.com/questions/68945080/pytube-exceptions-regexmatcherror-get-throttling-function-name-could-not-find)

Issue:  [1707](https://github.com/pytube/pytube/issues/1707)