### PR TITLE
fix: get_transform_object TEMPORARY FIX

### DIFF
--- a/pytube/cipher.py
+++ b/pytube/cipher.py
@@ -223,8 +223,12 @@ def get_transform_object(js: str, var: str) -> List[str]:
     logger.debug("getting transform object")
     regex = re.compile(pattern, flags=re.DOTALL)
     transform_match = regex.search(js)
+    
     if not transform_match:
-        raise RegexMatchError(caller="get_transform_object", pattern=pattern)
+        # commented the line that raises the error, TEMPORARY FIX
+        # raise RegexMatchError(caller="get_transform_object", pattern=pattern)
+        logger.error(f"No match found for pattern: {pattern}")
+        return []  # Return an empty list if no match is found
 
     return transform_match.group(1).replace("\n", " ").split(", ")
 


### PR DESCRIPTION
Temporarily Fixed the error

```
pytube.exceptions.RegexMatchError: get_transform_object
could not find match for var for={(.*?)}
```