### PR TITLE
Fix AgeRestrictedError #1620

### DIFF
--- a/pytube/innertube.py
+++ b/pytube/innertube.py
@@ -220,7 +220,7 @@ _token_file = os.path.join(_cache_dir, 'tokens.json')
 
 class InnerTube:
     """Object for interacting with the innertube API."""
-    def __init__(self, client='ANDROID_MUSIC', use_oauth=False, allow_cache=True):
+    def __init__(self, client='ANDROID', use_oauth=False, allow_cache=True):
         """Initialize an InnerTube object.
 
         :param str client:


### PR DESCRIPTION
**pytube** raising AgeRestrictedError even when the video is not age-restricted so I have fixed the issue by following the [comment](https://github.com/pytube/pytube/issues/1620#issuecomment-1551597676)