### PR TITLE
removed progressive=True filter from get_highest_resolution()

### DIFF
--- a/pytube/query.py
+++ b/pytube/query.py
@@ -280,7 +280,7 @@ class StreamQuery(Sequence):
         )
 
     def get_highest_resolution(self) -> Optional[Stream]:
-        """Get highest resolution stream that is a progressive video.
+        """Get highest resolution stream.
 
         :rtype: :class:`Stream <Stream>` or None
         :returns:
@@ -288,7 +288,7 @@ class StreamQuery(Sequence):
             not found.
 
         """
-        return self.filter(progressive=True).order_by("resolution").last()
+        return self.order_by("resolution").last()
 
     def get_audio_only(self, subtype: str = "mp4") -> Optional[Stream]:
         """Get highest bitrate audio stream for given codec (defaults to mp4)


### PR DESCRIPTION
Hi, this is my first attempt at proposing a patch to an open-source github repo, it's pretty simple so here goes. It's not really a fix, more like a small change that makes the functions more understandable.

I found it a bit confusing at first at why I only got progressive streams from this function until about 20 minutes later when I checked the description and found that the function indeed filtered on progressive streams. I had created an issue in this repo so I propose this fix to make the function a little bit more adaptable. Is it possible to link this pull request to the issue I created?