### PR TITLE
Fixed problem with certain videos while logged in.

### DIFF
--- a/pytube/__main__.py
+++ b/pytube/__main__.py
@@ -250,7 +250,7 @@ class YouTube:
     def bypass_age_gate(self):
         """Attempt to update the vid_info by bypassing the age gate."""
         innertube = InnerTube(
-            client='ANDROID_EMBED',
+            client='ANDROID',
             use_oauth=self.use_oauth,
             allow_cache=self.allow_oauth_cache
         )


### PR DESCRIPTION
Previously certain non age restricted videos would give the age restricted error, even when logged in, and the video is not age restricted. 
Checking innertube_response, it says 'This video is unavailable', 'Watch on Youtube'. 
The age_restricted property also confirms that the video is not age restricted.