### PR TITLE
Enhancement: Adding the is_private, id, and is_short property attributes. :)

### DIFF
--- a/pytube/__main__.py
+++ b/pytube/__main__.py
@@ -94,6 +94,14 @@ class YouTube:
     def __eq__(self, o: object) -> bool:
         # Compare types and urls, if they're same return true, else return false.
         return type(o) == type(self) and o.watch_url == self.watch_url
+    
+    @property
+    def is_private(self) -> bool:
+        try: 
+            self.streams
+            return False
+        except exceptions.VideoPrivate:
+            return True
 
     @property
     def watch_html(self):
@@ -364,6 +372,32 @@ class YouTube:
         :rtype: str
         """
         return self.vid_info.get("videoDetails", {}).get("shortDescription")
+    
+    @property
+    def id(self) -> str:
+        """Get the video id.
+        
+        :rtype: str
+        """
+        return self.watch_url.split("=")[1]
+    
+    @property
+    def is_short(self) -> bool:
+        """Gets whether the video is a short or not.
+        
+        :rtype: bool
+        """
+        yt_short_url = f'https://www.youtube.com/shorts/{self.id}'
+
+        try:
+            response = request.get(yt_short_url)
+
+            # so basically it's checking to see if the url got redirected,
+            # or if stayed as a short url or not. :) 
+            return response.geturl() == yt_short_url
+        
+        except request.URLError:
+            return False
 
     @property
     def rating(self) -> float:


### PR DESCRIPTION
I hope I followed all the git contribution guidelines, I didn't change any imports or deleted anything. I just added some stuff. I checked the tests but didn't see any specifics for all the properties so I didn't add any pytests for these properties. But I can try if need be. 

Basically I added 2 new properties to the YouTube class object: 

- id (like the last string at the end of the url) 

- is_private (checks this by using the self.streams attribute and if the VideoPrivate exception gets raised then we can return True, else False) 

- is_short (this one works by making a web request to the YT shorts url with the video id, if the request works with no final redirects, then it's a short, if not, it's not a short. This is ideally meant to be used with normal YT videos, not livestreams, but I think it would technically still work). 

Let me know if I need to do anything else to make this work! 