### PR TITLE
Added regex functionality to get video description

### DIFF
--- a/pytube/__main__.py
+++ b/pytube/__main__.py
@@ -363,7 +363,8 @@ class YouTube:
 
         :rtype: str
         """
-        return self.vid_info.get("videoDetails", {}).get("shortDescription")
+        video_description = extract.video_description_info(self.watch_html).replace('\\n', '\n')
+        return video_description
 
     @property
     def rating(self) -> float:

--- a/pytube/extract.py
+++ b/pytube/extract.py
@@ -212,6 +212,12 @@ def video_info_url(video_id: str, watch_url: str) -> str:
     )
     return _video_info_url(params)
 
+def video_description_info(watch_html: str):
+    try:
+        yt_description_result = regex_search(r'"(?<=description":{"simpleText":")([^}]+)', watch_html, group=0)
+    except RegexMatchError:
+        yt_description_result = None
+    return yt_description_result
 
 def video_info_url_age_restricted(video_id: str, embed_html: str) -> str:
     """Construct the video_info url.


### PR DESCRIPTION
Fix for #1833
- Added a video_description_info() function in pytube.extract to get video description from html.
- Passed the description value to the description property of the video. 