### PR TITLE
Fix ValueError when a playlist has no views

### DIFF
--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -375,9 +375,11 @@ class Playlist(Sequence):
         :return: Playlist view count
         :rtype: int
         """
-        # "1,234,567 views"
+        # "1,234,567 views" or "No views"
         views_text = self.sidebar_info[0]['playlistSidebarPrimaryInfoRenderer'][
             'stats'][1]['simpleText']
+        if views_text == "No views":
+            return 0
         # "1,234,567"
         count_text = views_text.split()[0]
         # "1234567"


### PR DESCRIPTION
### Problem:
``pytube`` raises a ValueError when accessing the ``views`` property of a playlist with no views.
Same problem as in #1052, which was fixed in #1058, but only in ``\contrib\search.py`` and not in ``\contrib\playlist.py``.

#### Example code:
```py
from pytube import Playlist
print(Playlist("https://www.youtube.com/playlist?list=PLyyu7uBtEOmvZkMNuAWK6dNhREPFPRnOK").views)
```

#### Error message:
```console
Traceback (most recent call last):
  File "C:\Users\user\Desktop\Code\pytube\test.py", line 2, in <module>
    print(Playlist("https://www.youtube.com/playlist?list=PLyyu7uBtEOmvZkMNuAWK6dNhREPFPRnOK").views)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\user\Desktop\Code\pytube\pytube\contrib\playlist.py", line 385, in views
    return int(count_text)
           ^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: 'No'
```

### Solution:
Check for ``"No views"`` and return 0.