### PR TITLE
Added Configurable client to bypass age restrictions

### DIFF
--- a/pytube/__main__.py
+++ b/pytube/__main__.py
@@ -247,10 +247,11 @@ class YouTube:
         self._vid_info = innertube_response
         return self._vid_info
 
-    def bypass_age_gate(self):
+    def bypass_age_gate(self,client='ANDROID'):
+        """client is now to be configured, i.e. ANDROID, ANDROID_EMBDED, WEB, etc"""
         """Attempt to update the vid_info by bypassing the age gate."""
         innertube = InnerTube(
-            client='ANDROID_EMBED',
+            client,
             use_oauth=self.use_oauth,
             allow_cache=self.allow_oauth_cache
         )


### PR DESCRIPTION
As clients may differ from user to user, I left the `client` to be configurable as it would help users to quickly switch `client` based on their requirements without running into `age  restrictions errors`.