### PR TITLE
fix #1865

### DIFF
--- a/pytube/contrib/search.py
+++ b/pytube/contrib/search.py
@@ -117,12 +117,17 @@ class Search:
             raw_video_list = item_renderer['contents']
             for video_details in raw_video_list:
                 # Skip over ads
-                if video_details.get('searchPyvRenderer', {}).get('ads', None):
+                if 'adSlotRenderer' in video_details or \
+                        video_details.get('searchPyvRenderer', {}).get('ads', None):
                     continue
 
                 # Skip "recommended" type videos e.g. "people also watched" and "popular X"
                 #  that break up the search results
                 if 'shelfRenderer' in video_details:
+                    continue
+
+                # Skip Shorts results
+                if 'reelShelfRenderer' in video_details:
                     continue
 
                 # Skip auto-generated "mix" playlist results


### PR DESCRIPTION
fix bug #1865:
'reelShelfRenderer' and 'adSlotRenderer' ignored in Search.fetch_and_parse function.