### PR TITLE
Enhancement: Enable resume on partially downloaded video stream

### DIFF
--- a/pytube/__main__.py
+++ b/pytube/__main__.py
@@ -250,7 +250,7 @@ class YouTube:
     def bypass_age_gate(self):
         """Attempt to update the vid_info by bypassing the age gate."""
         innertube = InnerTube(
-            client='ANDROID_EMBED',
+            client='ANDROID',
             use_oauth=self.use_oauth,
             allow_cache=self.allow_oauth_cache
         )


### PR DESCRIPTION
Enable resume on partially downloaded video streams  (e.g. on 403 Forbidden) rather than overwriting by default. Checks partial download file is a multiple of the `default_range_size` as a verification check.

Allows resume by re-running the CLI or API command.

Also includes fix for AgeRestrictedError bug: [issue 1712](https://github.com/pytube/pytube/issues/1712)
