### PR TITLE
Helpful indication for Mac users added in cli.rst

### DIFF
--- a/docs/user/cli.rst
+++ b/docs/user/cli.rst
@@ -11,6 +11,12 @@ To download the highest resolution progressive stream:
 
     $ pytube https://www.youtube.com/watch?v=2lAe1cqCOXo
 
+In MacOS, enclosing the link within quotes is required:
+
+.. code:: bash
+
+    $ pytube 'https://www.youtube.com/watch?v=2lAe1cqCOXo'
+
 To view available streams:
 
 .. code:: bash


### PR DESCRIPTION
Enclosing the youtube link within quotes was necessary for the instruction to run in MacOS, otherwise, the below error occurs: zsh: no matches found: https://www.youtube.com/watch?vv