### PR TITLE
Fixing CLI documentation error: Issue #1897

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ To download a video using the library in a script, you'll need to import the You
 
 Using the CLI is remarkably straightforward as well. To download a video at the highest progressive quality, you can use the following command:
 ```bash
-$ pytube https://youtube.com/watch?v=2lAe1cqCOXo
+$ pytube "https://youtube.com/watch?v=2lAe1cqCOXo"
 ```
 
 You can also do the same for a playlist:
 ```bash
-$ pytube https://www.youtube.com/playlist?list=PLS1QulWo1RIaJECMeUT4LFwJ-ghgoSH6n
+$ pytube "https://www.youtube.com/playlist?list=PLS1QulWo1RIaJECMeUT4LFwJ-ghgoSH6n"
 ```


### PR DESCRIPTION
Fix for issue #1897. The problem was that the README was incorrect in presenting how to use the CLI utility, I replaced it with a correct usage of the CLI (tested on fish, zsh, and bash and it works properly)