### PR TITLE
Updated YouTube XML format

### DIFF
--- a/pytube/captions.py
+++ b/pytube/captions.py
@@ -83,14 +83,15 @@ class Caption:
         """
         segments = []
         root = ElementTree.fromstring(xml_captions)
-        for i, child in enumerate(list(root)):
+        body = root.find("body")
+        for i, child in enumerate(list(body)):
             text = child.text or ""
             caption = unescape(text.replace("\n", " ").replace("  ", " "),)
             try:
-                duration = float(child.attrib["dur"])
+                duration = float(child.attrib["d"])
             except KeyError:
                 duration = 0.0
-            start = float(child.attrib["start"])
+            start = float(child.attrib["t"])
             end = start + duration
             sequence_number = i + 1  # convert from 0-indexed to 1.
             line = "{seq}\n{start} --> {end}\n{text}\n".format(

--- a/pytube/captions.py
+++ b/pytube/captions.py
@@ -88,10 +88,10 @@ class Caption:
             text = child.text or ""
             caption = unescape(text.replace("\n", " ").replace("  ", " "),)
             try:
-                duration = float(child.attrib["d"])
+                duration = float(child.attrib["d"])/1000
             except KeyError:
                 duration = 0.0
-            start = float(child.attrib["t"])
+            start = float(child.attrib["t"])/1000
             end = start + duration
             sequence_number = i + 1  # convert from 0-indexed to 1.
             line = "{seq}\n{start} --> {end}\n{text}\n".format(


### PR DESCRIPTION
YouTube XML format seems to be changed recently,
thus updated that changes in format to the code.
(If this update is only observed by me, please just ignore and close this PR)

The "changes" I updated:
* Timestamped elements location: child of `root` -> child of `body`
* start time keyword: `start` -> `t`
* duration keyword: `dur` -> `d`