### PR TITLE
[BUG FIX] fix Unexpected renderer encountered bug. Issue #1899, #1901

### DIFF
--- a/pytube/contrib/search.py
+++ b/pytube/contrib/search.py
@@ -149,6 +149,14 @@ class Search:
                 if 'backgroundPromoRenderer' in video_details:
                     continue
 
+                # Skip 'Sponsored/advertisement' results
+                if 'adSlotRenderer' in video_details:
+                    continue
+
+                # Skip 'Youtube Shorts' results 
+                if 'reelShelfRenderer' in video_details:
+                    continue
+
                 if 'videoRenderer' not in video_details:
                     logger.warning('Unexpected renderer encountered.')
                     logger.warning(f'Renderer name: {video_details.keys()}')


### PR DESCRIPTION
This fix addresses the following raised issues 
#1901 
#1899 

Problem: 
`Unexpected renderer encountered error` when `Search` results includes `"reelShelfRenderer"` or `"adSlotRenderere"` 

Implementation:
`reelShelfRenderer` refers to Youtube Shorts results in `Search`
`adSlotRenderer` refers to advertisement `Advertisement`

In `search.py::fetch_and_parse()` Added new conditions to skip `"reelShelfRenderer"` and `"adSlotRenderer"` 


Code Sample:
```
from pytube import Search
s = Search('YouTube Rewind')
print(len(s.results))
```
Previous Output(Error):
```
Unexpected renderer encountered.
Renderer name: dict_keys(['reelShelfRenderer'])
Search term: YouTube Rewind
Please open an issue at https://github.com/pytube/pytube/issues and provide this log output.
Unexpected renderer encountered.
Renderer name: dict_keys(['adSlotRenderer'])
Search term: YouTube Rewind
Please open an issue at https://github.com/pytube/pytube/issues and provide this log output.
Unexpected renderer encountered.
Renderer name: dict_keys(['reelShelfRenderer'])
Search term: YouTube Rewind
Please open an issue at https://github.com/pytube/pytube/issues and provide this log output.
17
```

NewOutput:
```
17
```
