### PR TITLE
Fix   can't download this video 1911

### DIFF
--- a/pytube/request.py
+++ b/pytube/request.py
@@ -159,6 +159,11 @@ def stream(
                     method="GET",
                     timeout=timeout
                 )
+                chunk = response.read()
+                if not chunk:
+                    break
+                downloaded += len(chunk)
+                yield chunk
             except URLError as e:
                 # We only want to skip over timeout errors, and
                 # raise any other URLError exceptions
@@ -185,12 +190,12 @@ def stream(
                 file_size = int(content_range)
             except (KeyError, IndexError, ValueError) as e:
                 logger.error(e)
-        while True:
-            chunk = response.read()
-            if not chunk:
-                break
-            downloaded += len(chunk)
-            yield chunk
+        # while True:
+        #     chunk = response.read()
+        #     if not chunk:
+        #         break
+        #     downloaded += len(chunk)
+        #     yield chunk
     return  # pylint: disable=R1711
 
 

--- a/pytube/request.py
+++ b/pytube/request.py
@@ -159,11 +159,6 @@ def stream(
                     method="GET",
                     timeout=timeout
                 )
-                chunk = response.read()
-                if not chunk:
-                    break
-                downloaded += len(chunk)
-                yield chunk
             except URLError as e:
                 # We only want to skip over timeout errors, and
                 # raise any other URLError exceptions
@@ -190,12 +185,12 @@ def stream(
                 file_size = int(content_range)
             except (KeyError, IndexError, ValueError) as e:
                 logger.error(e)
-        # while True:
-        #     chunk = response.read()
-        #     if not chunk:
-        #         break
-        #     downloaded += len(chunk)
-        #     yield chunk
+        while True:
+            chunk = response.read()
+            if not chunk:
+                break
+            downloaded += len(chunk)
+            yield chunk
     return  # pylint: disable=R1711
 
 

--- a/pytube/request.py
+++ b/pytube/request.py
@@ -159,6 +159,11 @@ def stream(
                     method="GET",
                     timeout=timeout
                 )
+                chunk = response.read()
+                if not chunk:
+                    break
+                downloaded += len(chunk)
+                yield chunk
             except URLError as e:
                 # We only want to skip over timeout errors, and
                 # raise any other URLError exceptions
@@ -185,12 +190,6 @@ def stream(
                 file_size = int(content_range)
             except (KeyError, IndexError, ValueError) as e:
                 logger.error(e)
-        while True:
-            chunk = response.read()
-            if not chunk:
-                break
-            downloaded += len(chunk)
-            yield chunk
     return  # pylint: disable=R1711
 
 


### PR DESCRIPTION
Fix for #1911
- This commit moves a tiny part of the stream function so that the part gets involved in exception handling of the http responses. This handles the IncompleteRead Exception which was used only for the response and not the data chunk extracted from the response. 
- This change will also bring some encapsulation of the response and chunk extracting process.