### PR TITLE
Youtube update - Fixed var_regex pattern

### DIFF
--- a/pytube/cipher.py
+++ b/pytube/cipher.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 class Cipher:
     def __init__(self, js: str):
         self.transform_plan: List[str] = get_transform_plan(js)
-        var_regex = re.compile(r"^\w+\W")
+        var_regex = re.compile(r"^\$*\w+\W")
         var_match = var_regex.search(self.transform_plan[0])
         if not var_match:
             raise RegexMatchError(

--- a/pytube/cipher.py
+++ b/pytube/cipher.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 class Cipher:
     def __init__(self, js: str):
         self.transform_plan: List[str] = get_transform_plan(js)
-        var_regex = re.compile(r"^\$*\w+\W")
+        var_regex = re.compile(r"^\$?\w+\W")
         var_match = var_regex.search(self.transform_plan[0])
         if not var_match:
             raise RegexMatchError(


### PR DESCRIPTION
YouTube must've updated their code, the library breaks on this line:

`var_regex = re.compile(r"^\w+\W")`

Since the value begins with `$` I added an optional match:

`var_regex = re.compile(r"^\$?\w+\W")`

Tested and works.