### PR TITLE
bug fix: __init__: could not find match for ^\w+\W

### DIFF
--- a/pytube/cipher.py
+++ b/pytube/cipher.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 class Cipher:
     def __init__(self, js: str):
         self.transform_plan: List[str] = get_transform_plan(js)
-        var_regex = re.compile(r"^\w+\W")
+        var_regex = re.compile(r"^[\w\$_]+\W")
         var_match = var_regex.search(self.transform_plan[0])
         if not var_match:
             raise RegexMatchError(


### PR DESCRIPTION
New regix error emerged as a result of youtube changed some of its youtube methods.
changed to the regix so that it can adapt to these new changes made by yotube