### PR TITLE
Fixed KeyError on generate_srt_captions command

### DIFF
--- a/pytube/captions.py
+++ b/pytube/captions.py
@@ -76,38 +76,39 @@ class Caption:
         return time_fmt + ms
 
     def xml_caption_to_srt(self, xml_captions: str) -> str:
-    """Convert xml caption tracks to "SubRip Subtitle (srt)" format.
+      """Convert xml caption tracks to "SubRip Subtitle (srt)".
 
-    :param str xml_captions:
-        XML formatted caption tracks.
-    """
-    segments = []
-    root = ElementTree.fromstring(xml_captions)
-    for i, child in enumerate(list(root)):
-        text = child.text or ""
-        caption = unescape(text.replace("\n", " ").replace("  ", " "),)
-
-        try:
-            duration = float(child.attrib["dur"])
-        except KeyError:
-            duration = 0.0
-
-        try:
-            start = float(child.attrib["start"])
-        except KeyError:
-            start = 0.0
-
-        end = start + duration
-        sequence_number = i + 1
-
-        line = "{seq}\n{start} --> {end}\n{text}\n".format(
-            seq=sequence_number,
-            start=self.float_to_srt_time_format(start),
-            end=self.float_to_srt_time_format(end),
-            text=caption,
-        )
-        segments.append(line)
-    return "\n".join(segments).strip()
+      :param str xml_captions:
+          XML formatted caption tracks.
+      """
+      segments = []
+      root = ElementTree.fromstring(xml_captions)[1]
+      i=0
+      for child in list(root):
+          if child.tag == 'p':
+              caption = ''
+              if len(list(child))==0:
+                  continue
+              for s in list(child):
+                  if s.tag == 's':
+                      caption += ' ' + s.text
+              caption = unescape(caption.replace("\n", " ").replace("  ", " "),)
+              try:
+                  duration = float(child.attrib["d"])/1000.0
+              except KeyError:
+                  duration = 0.0
+              start = float(child.attrib["t"])/1000.0
+              end = start + duration
+              sequence_number = i + 1  # convert from 0-indexed to 1.
+              line = "{seq}\n{start} --> {end}\n{text}\n".format(
+                  seq=sequence_number,
+                  start=self.float_to_srt_time_format(start),
+                  end=self.float_to_srt_time_format(end),
+                  text=caption,
+              )
+              segments.append(line)
+              i += 1
+      return "\n".join(segments).strip()
 
 
     def download(

--- a/pytube/captions.py
+++ b/pytube/captions.py
@@ -76,31 +76,39 @@ class Caption:
         return time_fmt + ms
 
     def xml_caption_to_srt(self, xml_captions: str) -> str:
-        """Convert xml caption tracks to "SubRip Subtitle (srt)".
+    """Convert xml caption tracks to "SubRip Subtitle (srt)" format.
 
-        :param str xml_captions:
-            XML formatted caption tracks.
-        """
-        segments = []
-        root = ElementTree.fromstring(xml_captions)
-        for i, child in enumerate(list(root)):
-            text = child.text or ""
-            caption = unescape(text.replace("\n", " ").replace("  ", " "),)
-            try:
-                duration = float(child.attrib["dur"])
-            except KeyError:
-                duration = 0.0
+    :param str xml_captions:
+        XML formatted caption tracks.
+    """
+    segments = []
+    root = ElementTree.fromstring(xml_captions)
+    for i, child in enumerate(list(root)):
+        text = child.text or ""
+        caption = unescape(text.replace("\n", " ").replace("  ", " "),)
+
+        try:
+            duration = float(child.attrib["dur"])
+        except KeyError:
+            duration = 0.0
+
+        try:
             start = float(child.attrib["start"])
-            end = start + duration
-            sequence_number = i + 1  # convert from 0-indexed to 1.
-            line = "{seq}\n{start} --> {end}\n{text}\n".format(
-                seq=sequence_number,
-                start=self.float_to_srt_time_format(start),
-                end=self.float_to_srt_time_format(end),
-                text=caption,
-            )
-            segments.append(line)
-        return "\n".join(segments).strip()
+        except KeyError:
+            start = 0.0
+
+        end = start + duration
+        sequence_number = i + 1
+
+        line = "{seq}\n{start} --> {end}\n{text}\n".format(
+            seq=sequence_number,
+            start=self.float_to_srt_time_format(start),
+            end=self.float_to_srt_time_format(end),
+            text=caption,
+        )
+        segments.append(line)
+    return "\n".join(segments).strip()
+
 
     def download(
         self,


### PR DESCRIPTION
## Description

This PR fixes a `KeyError` in `xml_caption_to_srt` caused by missing `start` or `dur` attributes in XML captions. Default values of `0.0` are now used when these attributes are absent.

### Solved this:
* #1957

## Changes

- Added `try-except` blocks to handle missing `start` and `dur` attributes in `pytube/captions.py`.
- Provided default values to ensure smooth execution.