### PR TITLE
Changed line 272 and added a another line on 274

### DIFF
--- a/pytube/cipher.py
+++ b/pytube/cipher.py
@@ -269,8 +269,9 @@ def get_throttling_function_name(js: str) -> str:
         # a.C && (b = a.get("n")) && (b = Bpa[0](b), a.set("n", b),
         # Bpa.length || iha("")) }};
         # In the above case, `iha` is the relevant function name
-        r'a\.[a-zA-Z]\s*&&\s*\([a-z]\s*=\s*a\.get\("n"\)\)\s*&&\s*'
+        r'a\.[a-zA-Z]\s*&&\s*\([a-z]\s*=\s*a\.get\("n"\)\)\s*&&.*?\|\|\s*([a-z]+)',
         r'\([a-z]\s*=\s*([a-zA-Z0-9$]+)(\[\d+\])?\([a-z]\)',
+        r"\([a-z]\s*=\s*([a-zA-Z0-9$]+)(\[\d+\])\([a-z]\)",
     ]
     logger.debug('Finding throttling function name')
     for pattern in function_patterns:


### PR DESCRIPTION
Got the lines from [this comment](https://github.com/pytube/pytube/issues/1678#issuecomment-2227445621). It fixes the "pytube.exceptions.RegexMatchError: get_throttling_function_name: could not find match for multiple" issue