### PR TITLE
Change default client in Innertube class from ANDROID_MUSIC to WEB

### DIFF
--- a/pytube/innertube.py
+++ b/pytube/innertube.py
@@ -220,7 +220,7 @@ _token_file = os.path.join(_cache_dir, 'tokens.json')
 
 class InnerTube:
     """Object for interacting with the innertube API."""
-    def __init__(self, client='ANDROID_MUSIC', use_oauth=False, allow_cache=True):
+    def __init__(self, client='WEB', use_oauth=False, allow_cache=True):
         """Initialize an InnerTube object.
 
         :param str client:


### PR DESCRIPTION
The "ANDROID" and "ANDROID_MUSIC" options cause errors when extracting the transcript of a YouTube video on a PC, because the PC accesses YouTube via the web interface. 
We can do this change in our local after installing the library but when deploying any project which is using this pytube library for extracting the transcript will cause error there. It can resolved by this correction that I have made.
Since this module is mostly used in python codes which is why the default client should be set to "WEB" resolving the issue of multiple peoples.
